### PR TITLE
Move integration tests from GitHub workflow to shell scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,47 +1,33 @@
 name: CI
+
 on: [push, pull_request]
+
 jobs:
   buildifier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Download Buildifier
+      - name: "Checkout the source code"
+        uses: actions/checkout@v1
+      - name: "Download Buildifier"
         run: |
           curl --location --fail https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier --output /tmp/buildifier
-          chmod +x /tmp/buildifier
-      - name: Lint Starlark Files
-        run: /tmp/buildifier -mode check -lint warn -r .
+          chmod +x /tmp/buildifier && echo "::add-path::/tmp/"
+      - name: "Lint Starlark files"
+        run: buildifier -mode check -lint warn -r .
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-java@v1
+      - name: "Checkout the source code"
+        uses: actions/checkout@v1
+      - name: "Install JDK"
+        uses: actions/setup-java@v1
         with:
           java-version: "11.0.5"
-      - name: Download Bazelisk
+      - name: "Download Bazelisk"
         run: |
           curl --location --fail https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64 --output /tmp/bazelisk
-          chmod +x /tmp/bazelisk
-      - name: Analysis Tests
-        run: /tmp/bazelisk test //tests/analysis:tests
-      - name: Integration Test detekt_with_default_attributes
-        run: |
-          /tmp/bazelisk build //tests/integration:detekt_with_default_attributes
-          test -f bazel-bin/tests/integration/detekt_with_default_attributes_detekt_report.txt
-      - name: Integration Test detekt_with_strict_config
-        run: |
-          set +e
-          /tmp/bazelisk build //tests/integration:detekt_with_strict_config > /tmp/bazel.log 2>&1
-          export BAZEL_EXIT_CODE=$?
-          set -e
-          echo "Printing bazel.log (1 error expected)"
-          cat /tmp/bazel.log
-          grep "Build failed with 1 weighted issues" /tmp/bazel.log
-      - name: Integration Test detekt_xml_report
-        run: |
-          /tmp/bazelisk build //tests/integration:detekt_xml_report
-          test -f bazel-out/k8-fastbuild/bin/tests/integration/detekt_xml_report_detekt_report.xml
-      - name: Integration Test detekt_html_report
-        run: |
-          /tmp/bazelisk build //tests/integration:detekt_html_report
-          test -f bazel-out/k8-fastbuild/bin/tests/integration/detekt_html_report_detekt_report.html
+          chmod +x /tmp/bazelisk && echo "::add-path::/tmp/"
+      - name: "Analysis tests"
+        run: bazelisk test //tests/analysis:tests
+      - name: "Integration tests"
+        run: bash tests/integration/test_*.sh

--- a/tests/integration/test_default_attributes.sh
+++ b/tests/integration/test_default_attributes.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eou pipefail
+
+TARGET="detekt_with_default_attributes"
+OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
+
+bazelisk clean
+bazelisk build //tests/integration:${TARGET}
+
+test ! -f "${OUTPUT_DIR}/${TARGET}_detekt_report.html"
+test -f "${OUTPUT_DIR}/${TARGET}_detekt_report.txt"
+test ! -f "${OUTPUT_DIR}/${TARGET}_detekt_report.xml"

--- a/tests/integration/test_default_attributes.sh
+++ b/tests/integration/test_default_attributes.sh
@@ -7,6 +7,8 @@ OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
 bazelisk clean
 bazelisk build //tests/integration:${TARGET}
 
+set -x
+
 test ! -f "${OUTPUT_DIR}/${TARGET}_detekt_report.html"
 test -f "${OUTPUT_DIR}/${TARGET}_detekt_report.txt"
 test ! -f "${OUTPUT_DIR}/${TARGET}_detekt_report.xml"

--- a/tests/integration/test_html_report.sh
+++ b/tests/integration/test_html_report.sh
@@ -7,6 +7,8 @@ OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
 bazelisk clean
 bazelisk build //tests/integration:${TARGET}
 
+set -x
+
 test -f "${OUTPUT_DIR}/${TARGET}_detekt_report.html"
 test -f "${OUTPUT_DIR}/${TARGET}_detekt_report.txt"
 test ! -f "${OUTPUT_DIR}/${TARGET}_detekt_report.xml"

--- a/tests/integration/test_html_report.sh
+++ b/tests/integration/test_html_report.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eou pipefail
+
+TARGET="detekt_html_report"
+OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
+
+bazelisk clean
+bazelisk build //tests/integration:${TARGET}
+
+test -f "${OUTPUT_DIR}/${TARGET}_detekt_report.html"
+test -f "${OUTPUT_DIR}/${TARGET}_detekt_report.txt"
+test ! -f "${OUTPUT_DIR}/${TARGET}_detekt_report.xml"

--- a/tests/integration/test_strict_config.sh
+++ b/tests/integration/test_strict_config.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -eou pipefail
 
-set +e
 bazelisk clean
+
+set +e
 bazelisk build //tests/integration:detekt_with_strict_config > /tmp/bazel.log > /dev/null
 BAZEL_EXIT_CODE=$?
 set -e

--- a/tests/integration/test_strict_config.sh
+++ b/tests/integration/test_strict_config.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eou pipefail
+
+set +e
+bazelisk clean
+bazelisk build //tests/integration:detekt_with_strict_config > /tmp/bazel.log > /dev/null
+BAZEL_EXIT_CODE=$?
+set -e
+
+test BAZEL_EXIT_CODE != 0

--- a/tests/integration/test_xml_report.sh
+++ b/tests/integration/test_xml_report.sh
@@ -7,6 +7,8 @@ OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
 bazelisk clean
 bazelisk build //tests/integration:${TARGET}
 
+set -x
+
 test ! -f "${OUTPUT_DIR}/${TARGET}_detekt_report.html"
 test -f "${OUTPUT_DIR}/${TARGET}_detekt_report.txt"
 test -f "${OUTPUT_DIR}/${TARGET}_detekt_report.xml"

--- a/tests/integration/test_xml_report.sh
+++ b/tests/integration/test_xml_report.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eou pipefail
+
+TARGET="detekt_xml_report"
+OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
+
+bazelisk clean
+bazelisk build //tests/integration:${TARGET}
+
+test ! -f "${OUTPUT_DIR}/${TARGET}_detekt_report.html"
+test -f "${OUTPUT_DIR}/${TARGET}_detekt_report.txt"
+test -f "${OUTPUT_DIR}/${TARGET}_detekt_report.xml"


### PR DESCRIPTION
Spent a lot of time with `sh_test` but it is weird and not very honest if we want to do actual integration testing.

* Tests can be run locally since the output path is not hardcoded.
* Expanded checks a bit to detect (detekt?) unwanted reports.
* Each test does `clean` to be a bit more hermetic.