### PR TITLE
Add support for a bunch of Detekt options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,16 @@ detekt(
 
 #### Attributes
 
-Name          | Type         | Default | Description
---------------|--------------|---------|--------
-`srcs`        | `label_list` | —       | A glob or an explicit list of Kotlin files.
-`config`      | `label`      | [The Detekt one](https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml) | A path or a target that represents a custom [Detekt configuration file](https://arturbosch.github.io/detekt/configurations.html).
-`parallel`    | `bool`       | `False` | Enables / disables the [Detekt `--parallel` option](https://arturbosch.github.io/detekt/cli.html).
-`html_report` | `bool`       |  `False`        | Enables / disables the HTML report generation. The report file name is `{target_name}_detekt_report.html`.
-`xml_report`  | `bool`       |  `False`        | Enables / disables the XML report generation. The report file name is `{target_name}_detekt_report.xml`. <br/><br/> FYI Detekt uses the Checkstyle XML reporting format which makes it compatible with tools like SonarQube and so on.
+Name                           | Type         | Default | Description
+-------------------------------|--------------|---------|--------
+`srcs`                         | `label_list` | —       | A glob or an explicit list of Kotlin files.
+`config`                       | `label`      | [The Detekt one](https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml) | A path or a target that represents a custom [Detekt configuration file](https://arturbosch.github.io/detekt/configurations.html).
+`html_report`                  | `bool`       | `False` | Enables / disables the HTML report generation. The report file name is `{target_name}_detekt_report.html`.
+`xml_report`                   | `bool`       | `False` | Enables / disables the XML report generation. The report file name is `{target_name}_detekt_report.xml`. <br/><br/> FYI Detekt uses the Checkstyle XML reporting format which makes it compatible with tools like SonarQube and so on.
+`build_upon_default_config`    | `bool`       | `False` | See [Detekt `--build-upon-default-config` option](https://arturbosch.github.io/detekt/cli.html).
+`disable_default_rulesets`     | `bool`       | `False` | See [Detekt `--disable-default-rulesets` option](https://arturbosch.github.io/detekt/cli.html).
+`fail_fast`                    | `bool`       | `False` | See [Detekt `--fail-fast` option](https://arturbosch.github.io/detekt/cli.html).
+`parallel`                     | `bool`       | `False` | See [Detekt `--parallel` option](https://arturbosch.github.io/detekt/cli.html).
 
 Note that a text report is always generated as `{target_name}_detekt_report.txt`.
 
@@ -78,9 +81,12 @@ Note that a text report is always generated as `{target_name}_detekt_report.txt`
 detekt(
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     config = "my-detekt-config.yml",
-    parallel = True,
     html_report = True,
     xml_report = True,
+    build_upon_default_config = True,
+    disable_default_rulesets = True,
+    fail_fast = True,
+    parallel = True,
 )
 ```
 

--- a/detekt/detekt.bzl
+++ b/detekt/detekt.bzl
@@ -32,9 +32,6 @@ def _impl(ctx):
         action_arguments.append("--baseline")
         action_arguments.append(ctx.file._baseline.path)
 
-    if ctx.attr.parallel:
-        action_arguments.append("--parallel")
-
     if ctx.attr._txt_report:
         txt_report = ctx.outputs.txt_report
         action_outputs.append(txt_report)
@@ -55,6 +52,18 @@ def _impl(ctx):
 
         action_arguments.append("--report")
         action_arguments.append("html:{}".format(html_report.path))
+
+    if ctx.attr.build_upon_default_config:
+        action_arguments.append("--build-upon-default-config")
+
+    if ctx.attr.disable_default_rulesets:
+        action_arguments.append("--disable-default-rulesets")
+
+    if ctx.attr.fail_fast:
+        action_arguments.append("--fail-fast")
+
+    if ctx.attr.parallel:
+        action_arguments.append("--parallel")
 
     ctx.actions.run(
         inputs = action_inputs,
@@ -92,10 +101,6 @@ detekt = rule(
             default = None,
             allow_single_file = True,
         ),
-        "parallel": attr.bool(
-            default = False,
-            doc = "As per Detekt documentation https://arturbosch.github.io/detekt/cli.html: Enables parallel compilation of source files. Should only be used if the analyzing project has more than ~200 Kotlin files.",
-        ),
         "_txt_report": attr.bool(
             default = True,
         ),
@@ -104,6 +109,22 @@ detekt = rule(
         ),
         "html_report": attr.bool(
             default = False,
+        ),
+        "build_upon_default_config": attr.bool(
+            default = False,
+            doc = "See Detekt '--build-upon-default-config' option: https://arturbosch.github.io/detekt/cli.html",
+        ),
+        "disable_default_rulesets": attr.bool(
+            default = False,
+            doc = "See Detekt '--disable-default-rulesets' option: https://arturbosch.github.io/detekt/cli.html",
+        ),
+        "fail_fast": attr.bool(
+            default = False,
+            doc = "See Detekt '--fail-fast' option: https://arturbosch.github.io/detekt/cli.html",
+        ),
+        "parallel": attr.bool(
+            default = False,
+            doc = "See Detekt '--parallel' option: https://arturbosch.github.io/detekt/cli.html",
         ),
     },
     outputs = {

--- a/tests/analysis/tests.bzl
+++ b/tests/analysis/tests.bzl
@@ -154,6 +154,6 @@ def test_suite(name):
         name = name,
         tests = [
             ":action_full_contents_test",
-            ":action_blank_contents_test"
+            ":action_blank_contents_test",
         ],
     )

--- a/tests/analysis/tests.bzl
+++ b/tests/analysis/tests.bzl
@@ -5,7 +5,20 @@ The rule analysis tests.
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@rules_detekt//detekt:detekt.bzl", "detekt")
 
-def _action_contents_test_impl(ctx):
+def expand_paths(ctx, values):
+    source_dir = ctx.build_file_path.replace("/BUILD", "")
+    output_dir = ctx.bin_dir.path
+
+    return [
+        value
+            .replace("{{source_dir}}", source_dir)
+            .replace("{{output_dir}}", output_dir)
+        for value in values
+    ]
+
+# Action full contents test
+
+def _action_full_contents_test_impl(ctx):
     env = analysistest.begin(ctx)
 
     actions = analysistest.target_actions(env)
@@ -22,13 +35,16 @@ def _action_contents_test_impl(ctx):
         "{{source_dir}}/config.yml",
         "--input",
         "{{source_dir}}/path A,{{source_dir}}/path B,{{source_dir}}/path C",
+        "--report",
+        "txt:{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.txt",
+        "--report",
+        "xml:{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.xml",
+        "--report",
+        "html:{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.html",
+        "--build-upon-default-config",
+        "--disable-default-rulesets",
+        "--fail-fast",
         "--parallel",
-        "--report",
-        "txt:{{output_dir}}/{{source_dir}}/test_target_detekt_report.txt",
-        "--report",
-        "xml:{{output_dir}}/{{source_dir}}/test_target_detekt_report.xml",
-        "--report",
-        "html:{{output_dir}}/{{source_dir}}/test_target_detekt_report.html",
     ])
 
     expected_inputs = expand_paths(env.ctx, [
@@ -41,9 +57,9 @@ def _action_contents_test_impl(ctx):
     ])
 
     expected_outputs = expand_paths(env.ctx, [
-        "{{output_dir}}/{{source_dir}}/test_target_detekt_report.txt",
-        "{{output_dir}}/{{source_dir}}/test_target_detekt_report.xml",
-        "{{output_dir}}/{{source_dir}}/test_target_detekt_report.html",
+        "{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.txt",
+        "{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.xml",
+        "{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.html",
     ])
 
     action = actions[0]
@@ -54,38 +70,90 @@ def _action_contents_test_impl(ctx):
 
     return analysistest.end(env)
 
-def expand_paths(ctx, values):
-    source_dir = ctx.build_file_path.replace("/BUILD", "")
-    output_dir = ctx.bin_dir.path
+action_full_contents_test = analysistest.make(_action_full_contents_test_impl)
 
-    return [
-        value
-            .replace("{{source_dir}}", source_dir)
-            .replace("{{output_dir}}", output_dir)
-        for value in values
-    ]
-
-action_contents_test = analysistest.make(_action_contents_test_impl)
-
-def _test_action_contents():
+def _test_action_full_contents():
     detekt(
-        name = "test_target",
+        name = "test_target_full",
         srcs = ["path A", "path B", "path C"],
         config = "config.yml",
-        parallel = True,
         html_report = True,
         xml_report = True,
+        build_upon_default_config = True,
+        disable_default_rulesets = True,
+        fail_fast = True,
+        parallel = True,
     )
 
-    action_contents_test(
-        name = "action_contents_test",
-        target_under_test = ":test_target",
+    action_full_contents_test(
+        name = "action_full_contents_test",
+        target_under_test = ":test_target_full",
     )
+
+# Action blank contents test
+
+def _action_blank_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    actions = analysistest.target_actions(env)
+    asserts.equals(env, 1, len(actions))
+
+    expected_arguments = expand_paths(env.ctx, [
+        "java",
+        "-Xms16m",
+        "-Xmx128m",
+        "-cp",
+        "external/detekt_cli_jar/file/downloaded:{{output_dir}}/external/rules_detekt/detekt/wrapper/bin_deploy.jar",
+        "io.buildfoundation.bazel.rulesdetekt.wrapper.Main",
+        "--input",
+        "{{source_dir}}/path A,{{source_dir}}/path B,{{source_dir}}/path C",
+        "--report",
+        "txt:{{output_dir}}/{{source_dir}}/test_target_blank_detekt_report.txt",
+    ])
+
+    expected_inputs = expand_paths(env.ctx, [
+        "{{source_dir}}/path A",
+        "{{source_dir}}/path B",
+        "{{source_dir}}/path C",
+        "{{output_dir}}/external/rules_detekt/detekt/wrapper/bin_deploy.jar",
+        "external/detekt_cli_jar/file/downloaded",
+    ])
+
+    expected_outputs = expand_paths(env.ctx, [
+        "{{output_dir}}/{{source_dir}}/test_target_blank_detekt_report.txt",
+    ])
+
+    action = actions[0]
+
+    asserts.equals(env, expected_arguments, action.argv)
+    asserts.equals(env, expected_inputs, [file.path for file in action.inputs.to_list()])
+    asserts.equals(env, expected_outputs, [file.path for file in action.outputs.to_list()])
+
+    return analysistest.end(env)
+
+action_blank_contents_test = analysistest.make(_action_blank_contents_test_impl)
+
+def _test_action_blank_contents():
+    detekt(
+        name = "test_target_blank",
+        srcs = ["path A", "path B", "path C"],
+    )
+
+    action_blank_contents_test(
+        name = "action_blank_contents_test",
+        target_under_test = ":test_target_blank",
+    )
+
+# Suite
 
 def test_suite(name):
-    _test_action_contents()
+    _test_action_full_contents()
+    _test_action_blank_contents()
 
     native.test_suite(
         name = name,
-        tests = [":action_contents_test"],
+        tests = [
+            ":action_full_contents_test",
+            ":action_blank_contents_test"
+        ],
     )


### PR DESCRIPTION
Seems like these shouldn’t be harmful.

Closes #23.