### PR TITLE
Change rule outputs declaration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,4 +30,4 @@ jobs:
       - name: "Analysis tests"
         run: bazelisk test //tests/analysis:tests
       - name: "Integration tests"
-        run: bash tests/integration/test_*.sh
+        run: find tests/integration -type f -name "test_*.sh" -exec bash {} \;

--- a/README.md
+++ b/README.md
@@ -72,13 +72,14 @@ Name                           | Type         | Default | Description
 `fail_fast`                    | `bool`       | `False` | See [Detekt `--fail-fast` option](https://arturbosch.github.io/detekt/cli.html).
 `parallel`                     | `bool`       | `False` | See [Detekt `--parallel` option](https://arturbosch.github.io/detekt/cli.html).
 
-Note that a text report is always generated as `{target_name}_detekt_report.txt`.
-
+Note that a text report is always generated as `{target_name}_detekt_report.txt`
+since Bazel requires rules to have outputs.
 
 #### Example
 
 ```python
 detekt(
+    name = "my_detekt",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     config = "my-detekt-config.yml",
     html_report = True,

--- a/tests/analysis/tests.bzl
+++ b/tests/analysis/tests.bzl
@@ -36,11 +36,11 @@ def _action_full_contents_test_impl(ctx):
         "--input",
         "{{source_dir}}/path A,{{source_dir}}/path B,{{source_dir}}/path C",
         "--report",
+        "html:{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.html",
+        "--report",
         "txt:{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.txt",
         "--report",
         "xml:{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.xml",
-        "--report",
-        "html:{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.html",
         "--build-upon-default-config",
         "--disable-default-rulesets",
         "--fail-fast",
@@ -57,9 +57,9 @@ def _action_full_contents_test_impl(ctx):
     ])
 
     expected_outputs = expand_paths(env.ctx, [
+        "{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.html",
         "{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.txt",
         "{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.xml",
-        "{{output_dir}}/{{source_dir}}/test_target_full_detekt_report.html",
     ])
 
     action = actions[0]

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -12,13 +12,13 @@ detekt(
 )
 
 detekt(
-    name = "detekt_xml_report",
-    srcs = glob(["src/main/kotlin/**/*.kt"]),
-    xml_report = True,
-)
-
-detekt(
     name = "detekt_html_report",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     html_report = True,
+)
+
+detekt(
+    name = "detekt_xml_report",
+    srcs = glob(["src/main/kotlin/**/*.kt"]),
+    xml_report = True,
 )

--- a/tests/integration/test_default_attributes.sh
+++ b/tests/integration/test_default_attributes.sh
@@ -4,6 +4,8 @@ set -eou pipefail
 TARGET="detekt_with_default_attributes"
 OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
 
+echo ":: Target with default attributes should generate text report."
+
 bazelisk clean
 bazelisk build //tests/integration:${TARGET}
 

--- a/tests/integration/test_html_report.sh
+++ b/tests/integration/test_html_report.sh
@@ -4,6 +4,8 @@ set -eou pipefail
 TARGET="detekt_html_report"
 OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
 
+echo ":: Target with HTML report attribute should generate text and HTML reports."
+
 bazelisk clean
 bazelisk build //tests/integration:${TARGET}
 

--- a/tests/integration/test_strict_config.sh
+++ b/tests/integration/test_strict_config.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eou pipefail
 
+echo ":: Target with strict config should fail."
+
 bazelisk clean
 
 set +e

--- a/tests/integration/test_xml_report.sh
+++ b/tests/integration/test_xml_report.sh
@@ -4,6 +4,8 @@ set -eou pipefail
 TARGET="detekt_xml_report"
 OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
 
+echo ":: Target with XML report attribute should generate text and XML reports."
+
 bazelisk clean
 bazelisk build //tests/integration:${TARGET}
 


### PR DESCRIPTION
* The `rule.outputs` attribute [is deprecated](https://docs.bazel.build/versions/master/skylark/lib/globals.html#rule).
* Using `DefaultInfo` allows Bazel to print all output files — previously only the `.txt` file was printed, now everything:

    ```
    Target //tests/integration:detekt_html_report up-to-date:
        bazel-bin/tests/integration/detekt_html_report_detekt_report.html
        bazel-bin/tests/integration/detekt_html_report_detekt_report.txt
    ```

Initially I thought that this change should resolve worker issues but nope. Still a good change though.