### PR TITLE
Add rule documentation generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,37 +59,7 @@ detekt(
 )
 ```
 
-#### Attributes
-
-Name                           | Type         | Default | Description
--------------------------------|--------------|---------|--------
-`srcs`                         | `label_list` | —       | A glob or an explicit list of Kotlin files.
-`config`                       | `label`      | [The Detekt one](https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml) | A path or a target that represents a custom [Detekt configuration file](https://arturbosch.github.io/detekt/configurations.html).
-`html_report`                  | `bool`       | `False` | Enables / disables the HTML report generation. The report file name is `{target_name}_detekt_report.html`.
-`xml_report`                   | `bool`       | `False` | Enables / disables the XML report generation. The report file name is `{target_name}_detekt_report.xml`. <br/><br/> FYI Detekt uses the Checkstyle XML reporting format which makes it compatible with tools like SonarQube and so on.
-`build_upon_default_config`    | `bool`       | `False` | See [Detekt `--build-upon-default-config` option](https://arturbosch.github.io/detekt/cli.html).
-`disable_default_rulesets`     | `bool`       | `False` | See [Detekt `--disable-default-rulesets` option](https://arturbosch.github.io/detekt/cli.html).
-`fail_fast`                    | `bool`       | `False` | See [Detekt `--fail-fast` option](https://arturbosch.github.io/detekt/cli.html).
-`parallel`                     | `bool`       | `False` | See [Detekt `--parallel` option](https://arturbosch.github.io/detekt/cli.html).
-
-Note that a text report is always generated as `{target_name}_detekt_report.txt`
-since Bazel requires rules to have outputs.
-
-#### Example
-
-```python
-detekt(
-    name = "my_detekt",
-    srcs = glob(["src/main/kotlin/**/*.kt"]),
-    config = "my-detekt-config.yml",
-    html_report = True,
-    xml_report = True,
-    build_upon_default_config = True,
-    disable_default_rulesets = True,
-    fail_fast = True,
-    parallel = True,
-)
-```
+See [available attributes](docs/rule.md).
 
 ### Execution
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,7 +28,6 @@ http_archive(
     name = "io_bazel_rules_kotlin",
     sha256 = rules_kotlin_sha,
     strip_prefix = "rules_kotlin-{v}".format(v = rules_kotlin_version),
-    type = "zip",
     urls = ["https://github.com/bazelbuild/rules_kotlin/archive/{v}.zip".format(v = rules_kotlin_version)],
 )
 
@@ -73,3 +72,22 @@ http_archive(
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
+
+# Stardoc (for documentation)
+
+stardoc_version = "0.4.0"
+
+stardoc_sha = "6d07d18c15abb0f6d393adbd6075cd661a2219faab56a9517741f0fc755f6f3c"
+
+http_archive(
+    name = "io_bazel_stardoc",
+    sha256 = stardoc_sha,
+    strip_prefix = "stardoc-{v}".format(v = stardoc_version),
+    urls = [
+        "https://github.com/bazelbuild/stardoc/archive/{v}.tar.gz".format(v = stardoc_version),
+    ],
+)
+
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,13 +22,13 @@ remote_jdk11_repos()
 
 rules_kotlin_version = "legacy-1.3.0-rc3"
 
-rules_kotlin_sha = "54678552125753d9fc0a37736d140f1d2e69778d3e52cf454df41a913b964ede"
+rules_kotlin_sha = "7cee5bd86d44ec7f643241197c28a2bced85614955adf0ed52a935296beb85b7"
 
 http_archive(
     name = "io_bazel_rules_kotlin",
     sha256 = rules_kotlin_sha,
     strip_prefix = "rules_kotlin-{v}".format(v = rules_kotlin_version),
-    urls = ["https://github.com/bazelbuild/rules_kotlin/archive/{v}.zip".format(v = rules_kotlin_version)],
+    urls = ["https://github.com/bazelbuild/rules_kotlin/archive/{v}.tar.gz".format(v = rules_kotlin_version)],
 )
 
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")

--- a/detekt/BUILD
+++ b/detekt/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+
+stardoc(
+    name = "docs",
+    out = "rule.md",
+    input = "detekt.bzl",
+    rule_template = "//docs:rule_template.vm",
+)

--- a/detekt/defs.bzl
+++ b/detekt/defs.bzl
@@ -86,11 +86,12 @@ detekt = rule(
         "srcs": attr.label_list(
             mandatory = True,
             allow_files = True,
+            doc = "A glob or an explicit list of Kotlin files.",
         ),
         "config": attr.label(
             default = None,
             allow_single_file = True,
-            doc = "Custom Detekt config file (must end with .yml). If not set Detekt will use its default configuration (mind the Detekt version) https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml",
+            doc = "Detekt config file. Otherwise [the default configuration](https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml) is used.",
         ),
         # TODO: Baselines are not fully supported yet due to Detekt relying on absolute paths which doesn't work with Bazel sandboxing.
         "_baseline": attr.label(
@@ -99,28 +100,31 @@ detekt = rule(
         ),
         "html_report": attr.bool(
             default = False,
+            doc = "Enables / disables the HTML report generation. The report file name is `{target_name}_detekt_report.html`.",
         ),
         "_txt_report": attr.bool(
             default = True,
         ),
         "xml_report": attr.bool(
             default = False,
+            doc = """Enables / disables the XML report generation. The report file name is `{target_name}_detekt_report.xml`. FYI Detekt uses the Checkstyle XML reporting format which makes it compatible with tools like SonarQube and so on.
+            """,
         ),
         "build_upon_default_config": attr.bool(
             default = False,
-            doc = "See Detekt '--build-upon-default-config' option: https://arturbosch.github.io/detekt/cli.html",
+            doc = "See [Detekt `--build-upon-default-config` option](https://arturbosch.github.io/detekt/cli.html).",
         ),
         "disable_default_rulesets": attr.bool(
             default = False,
-            doc = "See Detekt '--disable-default-rulesets' option: https://arturbosch.github.io/detekt/cli.html",
+            doc = "See [Detekt `--disable-default-rulesets` option](https://arturbosch.github.io/detekt/cli.html).",
         ),
         "fail_fast": attr.bool(
             default = False,
-            doc = "See Detekt '--fail-fast' option: https://arturbosch.github.io/detekt/cli.html",
+            doc = "See [Detekt `--fail-fast` option](https://arturbosch.github.io/detekt/cli.html).",
         ),
         "parallel": attr.bool(
             default = False,
-            doc = "See Detekt '--parallel' option: https://arturbosch.github.io/detekt/cli.html",
+            doc = "See [Detekt `--parallel` option](https://arturbosch.github.io/detekt/cli.html).",
         ),
     },
     provides = [DefaultInfo],

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,0 +1,1 @@
+exports_files(["rule_template.vm"])

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -1,0 +1,16 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+# Attributes
+
+Name           | Type                               | Default            | Description
+---------------|------------------------------------|--------------------|------------
+`name` | [`name`](https://docs.bazel.build/versions/master/build-ref.html#name) | — | A unique name for this target.
+`build_upon_default_config` | [`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html) | `False` | See [Detekt `--build-upon-default-config` option](https://arturbosch.github.io/detekt/cli.html).
+`config` | [`Label`](https://docs.bazel.build/versions/master/skylark/lib/Label.html) | `None` | Detekt config file. Otherwise [the default configuration](https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml) is used.
+`disable_default_rulesets` | [`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html) | `False` | See [Detekt `--disable-default-rulesets` option](https://arturbosch.github.io/detekt/cli.html).
+`fail_fast` | [`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html) | `False` | See [Detekt `--fail-fast` option](https://arturbosch.github.io/detekt/cli.html).
+`html_report` | [`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html) | `False` | Enables / disables the HTML report generation. The report file name is `{target_name}_detekt_report.html`.
+`parallel` | [`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html) | `False` | See [Detekt `--parallel` option](https://arturbosch.github.io/detekt/cli.html).
+`srcs` | [`[Label]`](https://docs.bazel.build/versions/master/skylark/lib/list.html) | — | A glob or an explicit list of Kotlin files.
+`xml_report` | [`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html) | `False` | Enables / disables the XML report generation. The report file name is `{target_name}_detekt_report.xml`. FYI Detekt uses the Checkstyle XML reporting format which makes it compatible with tools like SonarQube and so on.
+

--- a/docs/rule_template.vm
+++ b/docs/rule_template.vm
@@ -1,0 +1,31 @@
+# Attributes
+
+Name           | Type                               | Default            | Description
+---------------|------------------------------------|--------------------|------------
+#foreach ($attr in $ruleInfo.getAttributeList())
+#if ($attr.type == "NAME")
+  #set($type = "[`name`](https://docs.bazel.build/versions/master/build-ref.html#name)")
+#elseif ($attr.type == "BOOLEAN")
+  #set($type = "[`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html)")
+#elseif ($attr.type == "INT")
+  #set($type = "[`int`](https://docs.bazel.build/versions/master/skylark/lib/int.html)")
+#elseif ($attr.type == "INT_LIST")
+  #set($type = "[`[int]`](https://docs.bazel.build/versions/master/skylark/lib/list.html)")
+#elseif ($attr.type == "LABEL")
+  #set($type = "[`Label`](https://docs.bazel.build/versions/master/skylark/lib/Label.html)")
+#elseif ($attr.type == "LABEL_LIST")
+  #set($type = "[`[Label]`](https://docs.bazel.build/versions/master/skylark/lib/list.html)")
+#elseif ($attr.type == "STRING")
+  #set($type = "[`string`](https://docs.bazel.build/versions/master/skylark/lib/string.html)")
+#elseif ($attr.type == "STRING_LIST")
+  #set($type = "[`[string]`](https://docs.bazel.build/versions/master/skylark/lib/list.html)")
+#else
+  #set($type = "Unknown")
+#end
+#if ($attr.getMandatory())
+  #set($default = "—")
+#else
+  #set($default = "`$attr.defaultValue`")
+#end
+`$attr.name` | $type | $default | $attr.docString
+#end


### PR DESCRIPTION
Seems like docstrings are used exclusively for the generation, so let’s use that to our advantage.

The publishing is not automated at all, so the general flow is:

```
$ bazelisk build //detekt:docs
$ cp bazel-bin/detekt/rule.md docs
```

I think this is acceptable at this point since we are not changing attributes that often and don’t want to use GitHub pages to publish a dozen of attributes just for the automation purpose.