### PR TITLE
Refactor Detekt invocation

### DIFF
--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/SandboxExecutor.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/SandboxExecutor.kt
@@ -1,0 +1,59 @@
+package io.buildfoundation.bazel.rulesdetekt.wrapper
+
+import java.io.File
+import java.io.FileOutputStream
+import java.io.PrintStream
+import java.nio.charset.Charset
+import java.util.concurrent.atomic.AtomicReference
+
+interface SandboxExecutor {
+
+    data class Result(val code: Int, val stdout: String, val stderr: String)
+
+    fun execute(arguments: Array<String>): Result
+
+    class Impl(private val executor: SandboxedExecutor) : SandboxExecutor {
+
+        override fun execute(arguments: Array<String>): Result {
+            val systemStdout = System.out
+            val systemStderr = System.err
+
+            val sandboxStdoutFile = File("sandbox-stdout.txt")
+            val sandboxStderrFile = File("sandbox-stderr.txt")
+
+            val result = AtomicReference<SandboxedExecutor.Result>()
+
+            PrintStream(FileOutputStream(sandboxStdoutFile).buffered()).use { sandboxStdout ->
+                PrintStream(FileOutputStream(sandboxStderrFile).buffered()).use { sandboxStderr ->
+                    System.setOut(sandboxStdout)
+                    System.setErr(sandboxStderr)
+
+                    result.set(executor.execute(arguments))
+
+                    listOf(sandboxStdout, sandboxStderr).forEach {
+                        it.flush()
+                        it.close()
+                    }
+                }
+            }
+
+            System.setOut(systemStdout)
+            System.setErr(systemStderr)
+
+            return Charset.defaultCharset().let { charset ->
+                val code = when (result.get() ?: SandboxedExecutor.Result.Failure) {
+                    SandboxedExecutor.Result.Success -> 0
+                    SandboxedExecutor.Result.Failure -> 1
+                }
+
+                val stdout = sandboxStdoutFile.readText(charset)
+                val stderr = sandboxStderrFile.readText(charset)
+
+                sandboxStdoutFile.delete()
+                sandboxStderrFile.delete()
+
+                Result(code, stdout, stderr)
+            }
+        }
+    }
+}

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/SandboxExecutor.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/SandboxExecutor.kt
@@ -30,10 +30,11 @@ interface SandboxExecutor {
 
                     result.set(executor.execute(arguments))
 
-                    listOf(sandboxStdout, sandboxStderr).forEach {
-                        it.flush()
-                        it.close()
-                    }
+                    sandboxStdout.flush()
+                    sandboxStdout.close()
+
+                    sandboxStderr.flush()
+                    sandboxStderr.close()
                 }
             }
 

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/SandboxedExecutor.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/SandboxedExecutor.kt
@@ -1,0 +1,48 @@
+package io.buildfoundation.bazel.rulesdetekt.wrapper
+
+import java.lang.reflect.InvocationTargetException
+
+interface SandboxedExecutor {
+
+    enum class Result { Success, Failure }
+
+    fun execute(arguments: Array<String>): Result
+
+    object DetektExecutor : SandboxedExecutor {
+
+        override fun execute(arguments: Array<String>): Result = try {
+            executeRunner(arguments)
+            Result.Success
+        } catch (e: IllegalStateException) {
+            System.err.println("Detekt access error: ${e.message}")
+            Result.Failure
+        } catch (e: InvocationTargetException) {
+            e.cause?.printStackTrace()
+            Result.Failure
+        } catch (e: Exception) {
+            System.err.println("Unknown error")
+            e.printStackTrace()
+            Result.Failure
+        }
+
+        private fun executeRunner(arguments: Array<String>) {
+            val mainClass = try {
+                Class.forName("io.gitlab.arturbosch.detekt.cli.Main")
+            } catch (e: ClassNotFoundException) {
+                throw IllegalStateException("Detekt main class not found", e)
+            }
+
+            val runner = try {
+                mainClass.declaredMethods.first { it.name == "buildRunner" }.invoke(null, arguments)
+            } catch (e: NoSuchElementException) {
+                throw IllegalStateException("Detekt runner building method not found", e)
+            }
+
+            try {
+                runner.javaClass.declaredMethods.first { it.name == "execute" }.invoke(runner)
+            } catch (e: NoSuchElementException) {
+                throw IllegalStateException("Detekt runner execute method not found", e)
+            }
+        }
+    }
+}

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/SandboxedExecutor.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/SandboxedExecutor.kt
@@ -8,7 +8,7 @@ interface SandboxedExecutor {
 
     fun execute(arguments: Array<String>): Result
 
-    object DetektExecutor : SandboxedExecutor {
+    class DetektExecutor : SandboxedExecutor {
 
         override fun execute(arguments: Array<String>): Result = try {
             executeRunner(arguments)

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/main.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/main.kt
@@ -2,17 +2,11 @@
 
 package io.buildfoundation.bazel.rulesdetekt.wrapper
 
-import java.io.File
-import java.io.FileOutputStream
-import java.io.PrintStream
-import java.nio.charset.Charset
-import java.security.Permission
-import java.util.concurrent.atomic.AtomicInteger
-import kotlin.concurrent.thread
+import kotlin.system.exitProcess
 
 /**
  * Wrapper expects Detekt CLI jar on classpath.
- * All wrapper arguments are passed to Detekt main method.
+ * All wrapper arguments are passed to Detekt.
  *
  * What this wrapper does:
  * - Silents Detekt's stdout/stderr (it is not configurable in Detekt).
@@ -22,75 +16,13 @@ import kotlin.concurrent.thread
  * - By turning it into Persistent Worker
  * - By fixing Detekt design issues like absolute paths in reports/baselines.
  */
-fun main(rawArgs: Array<String>) {
-    val originalStdout = System.out
-    val originalStderr = System.err
+fun main(arguments: Array<String>) {
+    val result = SandboxExecutor.Impl(SandboxedExecutor.DetektExecutor).execute(arguments)
 
-    val interceptedExitCode = AtomicInteger()
-
-    val detektStdoutFile = File("detekt-stdout.txt")
-    val detektStderrFile = File("detekt-stderr.txt")
-
-    val defaultCharset = Charset.defaultCharset()
-
-    PrintStream(FileOutputStream(detektStdoutFile).buffered()).use { detektStdout ->
-        PrintStream(FileOutputStream(detektStderrFile).buffered()).use { detektStderr ->
-
-            val detektMainClass: Class<*>
-
-            try {
-                detektMainClass = Class.forName("io.gitlab.arturbosch.detekt.cli.Main")
-            } catch (e: ClassNotFoundException) {
-                throw IllegalStateException("Cannot find Detekt's main class in classpath, it might be due to custom Detekt version or an incompatible change on Detekt's side, detekt_rules_error_code_1", e)
-            }
-
-            System.setOut(detektStdout)
-            System.setErr(detektStderr)
-
-            Runtime.getRuntime().addShutdownHook(thread(start = false) {
-                if (interceptedExitCode.get() != 0) {
-                    // Remap streams back in case our code below crashes lol.
-                    System.setOut(originalStdout)
-                    System.setErr(originalStderr)
-
-                    detektStdout.flush()
-                    detektStdout.close()
-
-                    detektStderr.flush()
-                    detektStderr.close()
-
-                    detektStdoutFile
-                            .bufferedReader(defaultCharset)
-                            .useLines { lines ->
-                                lines.forEach { originalStdout.println(it) }
-                            }
-
-                    detektStderrFile
-                            .bufferedReader(defaultCharset)
-                            .useLines { lines ->
-                                lines.forEach { originalStderr.println(it) }
-                            }
-                }
-            })
-
-            System.setSecurityManager(object : SecurityManager() {
-                override fun checkExit(code: Int) {
-                    interceptedExitCode.set(code)
-                }
-
-                override fun checkPermission(perm: Permission?) {
-                    // Pass-through.
-                }
-
-                override fun checkPermission(perm: Permission?, context: Any?) {
-                    // Pass-through.
-                }
-            })
-
-            detektMainClass
-                    .declaredMethods
-                    .first { it.name == "main" }
-                    .invoke(null, rawArgs)
-        }
+    if (result.code != 0) {
+        System.out.println(result.stdout)
+        System.err.println(result.stderr)
     }
+
+    exitProcess(result.code)
 }

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/main.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/main.kt
@@ -17,7 +17,7 @@ import kotlin.system.exitProcess
  * - By fixing Detekt design issues like absolute paths in reports/baselines.
  */
 fun main(arguments: Array<String>) {
-    val result = SandboxExecutor.Impl(SandboxedExecutor.DetektExecutor).execute(arguments)
+    val result = SandboxExecutor.Impl(SandboxedExecutor.DetektExecutor()).execute(arguments)
 
     if (result.code != 0) {
         System.out.println(result.stdout)


### PR DESCRIPTION
Workers don’t give us the luxury of allowing Detekt [to kill the process](https://github.com/arturbosch/detekt/blob/280eab8adbb034371c8ea69725bf88e66264e718/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt#L14-L28). Fortunately there is a public method we can access that doesn’t do that.

At the same time, the workers protocol requires passing the stdout / stderr content via the `WorkResponse` proto, reserving the real stdout / stdin for the communication itself, so the code was refactored to mitigate this. 

In the future the `main` method will either do current actions (as a non-worker) or enter a loop of reading / writing protos with the execution in between (as a worker).