### PR TITLE
Add persistent workers support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,4 +30,4 @@ jobs:
       - name: "Analysis tests"
         run: bazelisk test //tests/analysis:tests
       - name: "Integration tests"
-        run: find tests/integration -type f -name "test_*.sh" -exec bash {} \;
+        run: bash tests/integration/suite.sh

--- a/README.md
+++ b/README.md
@@ -3,25 +3,19 @@
 The [Detekt](https://github.com/arturbosch/detekt) (a Kotlin static analysis tool) integration
 for [the Bazel build system](https://bazel.build).
 
-- [Overview](#overview)
-- [Usage](#usage)
-    - [`WORKSPACE` Configuration](#workspace-configuration)
-    - [`BUILD` Configuration](#build-configuration)
-    - [Execution](#execution)
-
 ## Overview
 
 Features:
 
-- user-provided Detekt configuration;
-- text, XML and HTML report generation;
-- parallel Detekt compilation.
+- [persistent workers](https://blog.bazel.build/2015/12/10/java-workers.html) support;
+- configuration files;
+- HTML, text and XML reports;
+- [and more](docs/rule.md).
 
 Upcoming features:
 
-- baseline files (blocked by Detekt outputting and reading absolute paths in baselines, see [#3](https://github.com/buildfoundation/bazel_rules_detekt/issues/3));
-- Bazel persistent worker mode;
-- user-provided Detekt CLI JAR (blocked by the persistent worker mode due to potential changes in classloading, see [#14](https://github.com/buildfoundation/bazel_rules_detekt/issues/14)).
+- baseline files (blocked by Detekt using absolute paths in baselines, see [#3](https://github.com/buildfoundation/bazel_rules_detekt/issues/3));
+- user-provided Detekt CLI JAR.
 
 ## Usage
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,6 +54,28 @@ http_file(
     ],
 )
 
+# Protocol Buffers (for worker protocol)
+
+rules_proto_version = "97d8af4dc474595af3900dd85cb3a29ad28cc313"
+
+rules_proto_sha = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208"
+
+http_archive(
+    name = "rules_proto",
+    sha256 = rules_proto_sha,
+    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/{v}.tar.gz".format(v = rules_proto_version),
+        "https://github.com/bazelbuild/rules_proto/archive/{v}.tar.gz".format(v = rules_proto_version),
+    ],
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
+
 # Skylib (for analysis testing)
 
 skylib_version = "1.0.2"

--- a/detekt/defs.bzl
+++ b/detekt/defs.bzl
@@ -17,6 +17,14 @@ def _impl(ctx):
 
     detekt_arguments = ctx.actions.args()
 
+    # Detekt arguments are passed in a file. The file path is a special @-named argument.
+    # See https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javac.html#BHCJEIBB
+    # A worker execution replaces the @-argument with the "--persistent_worker" one.
+    # A non-worker execution preserves the argument which is eventually expanded to regular arguments.
+
+    detekt_arguments.set_param_file_format("multiline")
+    detekt_arguments.use_param_file("@%s", use_always = True)
+
     if ctx.attr.config != None:
         action_inputs.append(ctx.file.config)
         detekt_arguments.add("--config", ctx.file.config)
@@ -64,7 +72,7 @@ def _impl(ctx):
         tools = [ctx.file._detekt_cli_jar],
         executable = ctx.executable._detekt_wrapper,
         execution_requirements = {
-            "supports-workers": "0",
+            "supports-workers": "1",
         },
         arguments = [action_arguments, detekt_arguments],
     )

--- a/detekt/wrapper/BUILD
+++ b/detekt/wrapper/BUILD
@@ -1,9 +1,21 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
-load("@rules_java//java:defs.bzl", "java_binary")
+load("@rules_java//java:defs.bzl", "java_binary", "java_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "worker_protocol_proto",
+    srcs = ["src/main/proto/worker_protocol.proto"],
+)
+
+java_proto_library(
+    name = "worker_protocol_java_proto",
+    deps = [":worker_protocol_proto"],
+)
 
 kt_jvm_library(
     name = "lib",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
+    deps = [":worker_protocol_java_proto"],
 )
 
 java_binary(

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/Application.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/Application.kt
@@ -1,0 +1,44 @@
+package io.buildfoundation.bazel.rulesdetekt.wrapper
+
+import bazel.worker.WorkerProtocol
+import kotlin.system.exitProcess
+
+interface Application {
+
+    fun run(arguments: Array<String>)
+
+    class Worker(private val executor: SandboxExecutor) : Application {
+
+        override fun run(arguments: Array<String>) {
+            while (true) {
+                val result = WorkerProtocol.WorkRequest.parseDelimitedFrom(System.`in`).let {
+                    executor.execute(it.argumentsList.toTypedArray())
+                }
+
+                WorkerProtocol.WorkResponse.newBuilder()
+                        .apply {
+                            if (result.code != 0) {
+                                output = listOf(result.stdout, result.stderr).joinToString(separator = "\n")
+                            }
+                        }
+                        .setExitCode(result.code)
+                        .build()
+                        .writeDelimitedTo(System.out)
+            }
+        }
+    }
+
+    class OneShot(private val executor: SandboxExecutor) : Application {
+
+        override fun run(arguments: Array<String>) {
+            val result = executor.execute(arguments)
+
+            if (result.code != 0) {
+                System.out.println(result.stdout)
+                System.err.println(result.stderr)
+            }
+
+            exitProcess(result.code)
+        }
+    }
+}

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/main.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/main.kt
@@ -2,8 +2,6 @@
 
 package io.buildfoundation.bazel.rulesdetekt.wrapper
 
-import kotlin.system.exitProcess
-
 /**
  * Wrapper expects Detekt CLI jar on classpath.
  * All wrapper arguments are passed to Detekt.
@@ -13,16 +11,16 @@ import kotlin.system.exitProcess
  * - Prints Detekt's stdout/stderr if Detekt exits with non-zero exit code.
  *
  * Later it might be enhanced:
- * - By turning it into Persistent Worker
  * - By fixing Detekt design issues like absolute paths in reports/baselines.
  */
 fun main(arguments: Array<String>) {
-    val result = SandboxExecutor.Impl(SandboxedExecutor.DetektExecutor()).execute(arguments)
+    val executor = SandboxExecutor.Impl(SandboxedExecutor.DetektExecutor())
 
-    if (result.code != 0) {
-        System.out.println(result.stdout)
-        System.err.println(result.stderr)
+    val application = if ("--persistent_worker" in arguments) {
+        Application.Worker(executor)
+    } else {
+        Application.OneShot(executor)
     }
 
-    exitProcess(result.code)
+    application.run(arguments)
 }

--- a/detekt/wrapper/src/main/proto/worker_protocol.proto
+++ b/detekt/wrapper/src/main/proto/worker_protocol.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+option java_package = "bazel.worker";
+
+message Input {
+  string path = 1;
+  bytes digest = 2;
+}
+
+message WorkRequest {
+  repeated string arguments = 1;
+  repeated Input inputs = 2;
+  int32 request_id = 3;
+}
+
+message WorkResponse {
+  int32 exit_code = 1;
+  string output = 2;
+  int32 request_id = 3;
+}

--- a/tests/integration/suite.sh
+++ b/tests/integration/suite.sh
@@ -5,11 +5,11 @@ DIR="tests/integration"
 
 for STRATEGY in "local" "worker"; do
     echo ":: Executing with the [${STRATEGY}] strategy."
-    echo "build --strategy=Detekt=${STRATEGY}" > "${DIR}/.bazelrc"
+    echo "build --strategy=Detekt=${STRATEGY}" > ".bazelrc"
 
     bazelisk clean
 
     time find ${DIR} -type f -name "test_*.sh" -exec bash {} \;
 done
 
-rm "${DIR}/.bazelrc"
+rm ".bazelrc"

--- a/tests/integration/suite.sh
+++ b/tests/integration/suite.sh
@@ -9,7 +9,7 @@ for STRATEGY in "local" "worker"; do
 
     bazelisk clean
 
-    time find ${DIR} -type f -name "test_*.sh" -exec bash {} \;
+    find ${DIR} -type f -name "test_*.sh" -exec bash {} \;
 done
 
 rm ".bazelrc"

--- a/tests/integration/suite.sh
+++ b/tests/integration/suite.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eou pipefail
+
+DIR="tests/integration"
+
+for STRATEGY in "local" "worker"; do
+    echo ":: Executing with the [${STRATEGY}] strategy."
+    echo "build --strategy=Detekt=${STRATEGY}" > "${DIR}/.bazelrc"
+
+    bazelisk clean
+
+    time find ${DIR} -type f -name "test_*.sh" -exec bash {} \;
+done
+
+rm "${DIR}/.bazelrc"

--- a/tests/integration/test_default_attributes.sh
+++ b/tests/integration/test_default_attributes.sh
@@ -6,7 +6,6 @@ OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
 
 echo ":: Target with default attributes should generate text report."
 
-bazelisk clean
 bazelisk build //tests/integration:${TARGET}
 
 set -x

--- a/tests/integration/test_html_report.sh
+++ b/tests/integration/test_html_report.sh
@@ -6,7 +6,6 @@ OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
 
 echo ":: Target with HTML report attribute should generate text and HTML reports."
 
-bazelisk clean
 bazelisk build //tests/integration:${TARGET}
 
 set -x

--- a/tests/integration/test_strict_config.sh
+++ b/tests/integration/test_strict_config.sh
@@ -3,8 +3,6 @@ set -eou pipefail
 
 echo ":: Target with strict config should fail."
 
-bazelisk clean
-
 set +e
 bazelisk build //tests/integration:detekt_with_strict_config > /tmp/bazel.log > /dev/null
 BAZEL_EXIT_CODE=$?

--- a/tests/integration/test_xml_report.sh
+++ b/tests/integration/test_xml_report.sh
@@ -6,7 +6,6 @@ OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
 
 echo ":: Target with XML report attribute should generate text and XML reports."
 
-bazelisk clean
 bazelisk build //tests/integration:${TARGET}
 
 set -x


### PR DESCRIPTION
TL;DR: without worker — 2.084s, with worker — 0.347s. JVM launches are not so fast, huh.

```console
$ touch tests/integration/src/main/kotlin/.../Cold.kt
$ bazelisk build //tests/integration:detekt_html_report --strategy=Detekt=local

INFO: Analyzed target //tests/integration:detekt_html_report (1 packages loaded, 4 targets configured).
INFO: Found 1 target...
Target //tests/integration:detekt_html_report up-to-date:
  bazel-bin/tests/integration/detekt_html_report_detekt_report.html
  bazel-bin/tests/integration/detekt_html_report_detekt_report.txt
INFO: Elapsed time: 2.167s, Critical Path: 2.00s
INFO: 1 process: 1 local.
INFO: Build completed successfully, 2 total actions

$ touch tests/integration/src/main/kotlin/.../Warm.kt
$ bazelisk build //tests/integration:detekt_html_report --strategy=Detekt=local

INFO: Analyzed target //tests/integration:detekt_html_report (1 packages loaded, 5 targets configured).
INFO: Found 1 target...
Target //tests/integration:detekt_html_report up-to-date:
  bazel-bin/tests/integration/detekt_html_report_detekt_report.html
  bazel-bin/tests/integration/detekt_html_report_detekt_report.txt
INFO: Elapsed time: 2.084s, Critical Path: 1.93s
INFO: 1 process: 1 local.
INFO: Build completed successfully, 2 total actions
```
vs.
```console
$ touch tests/integration/src/main/kotlin/.../Cold.kt
$ bazelisk build //tests/integration:detekt_html_report --strategy=Detekt=worker

INFO: Analyzed target //tests/integration:detekt_html_report (1 packages loaded, 4 targets configured).
INFO: Found 1 target...
Target //tests/integration:detekt_html_report up-to-date:
  bazel-bin/tests/integration/detekt_html_report_detekt_report.html
  bazel-bin/tests/integration/detekt_html_report_detekt_report.txt
INFO: Elapsed time: 2.035s, Critical Path: 1.87s
INFO: 1 process: 1 worker.
INFO: Build completed successfully, 2 total actions

$ touch tests/integration/src/main/kotlin/.../Warm.kt
$ bazelisk build //tests/integration:detekt_html_report --strategy=Detekt=worker

INFO: Analyzed target //tests/integration:detekt_html_report (1 packages loaded, 5 targets configured).
INFO: Found 1 target...
Target //tests/integration:detekt_html_report up-to-date:
  bazel-bin/tests/integration/detekt_html_report_detekt_report.html
  bazel-bin/tests/integration/detekt_html_report_detekt_report.txt
INFO: Elapsed time: 0.347s, Critical Path: 0.20s
INFO: 1 process: 1 worker.
INFO: Build completed successfully, 2 total actions
```
There is a downside though. Since the worker protocol is based on Protocol Buffers it forces us to compile Protocol Buffers from scratch which takes a while. Unfortunately, it is a side-effect of Bazel not distributing binaries and relates to everything proto-related (as I see it). 

Closes #7.