### PR TITLE
Switch to tar.gz from zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ rules_detekt_sha256 = "see-github-releases-page"
 http_archive(
     name = "rules_detekt",
     sha256 = rules_detekt_sha256,
-    strip_prefix = "bazel_rules_detekt-%s" % rules_detekt_version,
-    url = "https://github.com/buildfoundation/bazel_rules_detekt/archive/%s.tar.gz" % rules_detekt_version,
+    strip_prefix = "bazel_rules_detekt-{v}".format(v = rules_detekt_version),
+    url = "https://github.com/buildfoundation/bazel_rules_detekt/archive/{v}.tar.gz".format(v = rules_detekt_version),
 )
 
 load("@rules_detekt//detekt:dependencies.bzl", "rules_detekt_dependencies")

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ http_archive(
     name = "rules_detekt",
     sha256 = rules_detekt_sha256,
     strip_prefix = "bazel_rules_detekt-%s" % rules_detekt_version,
-    url = "https://github.com/buildfoundation/bazel_rules_detekt/archive/%s.zip" % rules_detekt_version,
+    url = "https://github.com/buildfoundation/bazel_rules_detekt/archive/%s.tar.gz" % rules_detekt_version,
 )
 
 load("@rules_detekt//detekt:dependencies.bzl", "rules_detekt_dependencies")

--- a/detekt/dependencies.bzl
+++ b/detekt/dependencies.bzl
@@ -41,12 +41,12 @@ def rules_detekt_dependencies():
     # JVM External
 
     rules_jvm_external_version = "3.0"
-    rules_jvm_external_sha = "62133c125bf4109dfd9d2af64830208356ce4ef8b165a6ef15bbff7460b35c3a"
+    rules_jvm_external_sha = "baa842cbc67aec78408aec3e480b2e94dbdd14d6b0170d3a3ee14a0e1a5bb95f"
 
     maybe(
         repo_rule = http_archive,
         name = "rules_jvm_external",
-        url = "https://github.com/bazelbuild/rules_jvm_external/archive/{v}.zip".format(v = rules_jvm_external_version),
+        url = "https://github.com/bazelbuild/rules_jvm_external/archive/{v}.tar.gz".format(v = rules_jvm_external_version),
         strip_prefix = "rules_jvm_external-{v}".format(v = rules_jvm_external_version),
         sha256 = rules_jvm_external_sha,
     )


### PR DESCRIPTION
* `rules_java` — `tar.gz` releases.
* `rules_jvm_external` — no releases, but uses `zip` for SHA-256.
* `rules_kotlin` — `tar.gz` releases.
* `rules_proto` — no releases, but uses `tar.gz` for SHA-256.
* Skylib — `tar.gz` releases.
* Stardoc — no releases, no SHA-256.

Generally `tar.gz` proves to be more efficient with text files.

```
   9.4K Dec 19 20:51 bazel_rules_detekt-0.2.0.tar.gz
    17K Dec 19 20:51 bazel_rules_detekt-0.2.0.zip
   1.8M Dec 19 21:00 rules_apple-0.19.0.tar.gz
   2.3M Dec 19 21:01 rules_apple-0.19.0.zip
   145K Dec 19 20:57 rules_jvm_external-3.0.tar.gz
   209K Dec 19 20:57 rules_jvm_external-3.0.zip
```