### PR TITLE
Remove multiplex workers support (for now)

### DIFF
--- a/detekt/defs.bzl
+++ b/detekt/defs.bzl
@@ -69,7 +69,7 @@ def _impl(ctx):
         executable = ctx.executable._detekt_wrapper,
         execution_requirements = {
             "supports-workers": "1",
-            "supports-multiplex-workers": "1",
+            "supports-multiplex-workers": "0",
         },
         arguments = [java_arguments, detekt_arguments],
     )

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/Application.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/Application.kt
@@ -1,5 +1,7 @@
 package io.buildfoundation.bazel.rulesdetekt.wrapper
 
+import io.reactivex.Scheduler
+
 internal interface Application {
 
     fun run(args: Array<String>)
@@ -22,12 +24,14 @@ internal interface Application {
     }
 
     class Worker(
+            private val scheduler: Scheduler,
             private val executable: WorkerExecutable,
             private val streams: WorkerStreams
     ) : Application {
 
         override fun run(args: Array<String>) {
             streams.request
+                    .subscribeOn(scheduler)
                     .map { executable.execute(it) }
                     .blockingSubscribe(streams.response)
         }

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/Application.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/Application.kt
@@ -1,7 +1,5 @@
 package io.buildfoundation.bazel.rulesdetekt.wrapper
 
-import io.reactivex.Scheduler
-
 internal interface Application {
 
     fun run(args: Array<String>)
@@ -24,18 +22,13 @@ internal interface Application {
     }
 
     class Worker(
-            private val scheduler: Scheduler,
             private val executable: WorkerExecutable,
             private val streams: WorkerStreams
     ) : Application {
 
         override fun run(args: Array<String>) {
             streams.request
-                    .subscribeOn(scheduler)
-                    .parallel()
-                    .runOn(scheduler)
                     .map { executable.execute(it) }
-                    .sequential()
                     .blockingSubscribe(streams.response)
         }
     }

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/main.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/main.kt
@@ -2,8 +2,6 @@
 
 package io.buildfoundation.bazel.rulesdetekt.wrapper
 
-import io.reactivex.schedulers.Schedulers
-
 /**
  * The wrapper purpose:
  *
@@ -16,7 +14,7 @@ fun main(arguments: Array<String>) {
     val consoleStreams = Streams.system()
 
     val application = if ("--persistent_worker" in arguments) {
-        Application.Worker(Schedulers.io(), WorkerExecutable.Impl(executable), WorkerStreams.Impl(consoleStreams))
+        Application.Worker(WorkerExecutable.Impl(executable), WorkerStreams.Impl(consoleStreams))
     } else {
         Application.OneShot(executable, consoleStreams, Platform.Impl())
     }

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/main.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/main.kt
@@ -2,6 +2,8 @@
 
 package io.buildfoundation.bazel.rulesdetekt.wrapper
 
+import io.reactivex.schedulers.Schedulers
+
 /**
  * The wrapper purpose:
  *
@@ -14,7 +16,7 @@ fun main(arguments: Array<String>) {
     val consoleStreams = Streams.system()
 
     val application = if ("--persistent_worker" in arguments) {
-        Application.Worker(WorkerExecutable.Impl(executable), WorkerStreams.Impl(consoleStreams))
+        Application.Worker(Schedulers.io(), WorkerExecutable.Impl(executable), WorkerStreams.Impl(consoleStreams))
     } else {
         Application.OneShot(executable, consoleStreams, Platform.Impl())
     }


### PR DESCRIPTION
For history: after internal testing we’ve determined that multiplexing might lead to deadlocks. In fact, [it is a documented behavior](https://docs.bazel.build/versions/master/multiplex-worker.html#warning).

Taking into account that this rule is the first one on GitHub to support multiplexing — I suggest to shelve it for now and do a better testing in the future. Especially since it is impossible to fallback to regular workers on the Bazel level. We are better off with stable boring workers than unstable fancy ones.