### PR TITLE
Replace Bazelisk invocations with Bazel.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,15 +2,19 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  VERSION_BAZELISK: "1.2.1"
+  VERSION_BUILDIFIER: "0.29.0"
+
 jobs:
   buildifier:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout the source code"
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.0.0
       - name: "Download Buildifier"
         run: |
-          curl --location --fail https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier --output /tmp/buildifier
+          curl --location --fail "https://github.com/bazelbuild/buildtools/releases/download/${VERSION_BUILDIFIER}/buildifier" --output /tmp/buildifier
           chmod +x /tmp/buildifier && echo "::add-path::/tmp/"
       - name: "Lint Starlark files"
         run: buildifier -mode check -lint warn -r .
@@ -18,18 +22,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout the source code"
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.0.0
       - name: "Install JDK"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.3.0
         with:
           java-version: "11.0.5"
       - name: "Download Bazelisk"
         run: |
-          curl --location --fail https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64 --output /tmp/bazelisk
-          chmod +x /tmp/bazelisk && echo "::add-path::/tmp/"
+          curl --location --fail "https://github.com/bazelbuild/bazelisk/releases/download/v${VERSION_BAZELISK}/bazelisk-linux-amd64" --output /tmp/bazel
+          chmod +x /tmp/bazel && echo "::add-path::/tmp/"
       - name: "Unit tests"
-        run: bazelisk test //detekt/wrapper:tests
+        run: bazel test //detekt/wrapper:tests
       - name: "Analysis tests"
-        run: bazelisk test //tests/analysis:tests
+        run: bazel test //tests/analysis:tests
       - name: "Integration tests"
         run: bash tests/integration/suite.sh

--- a/docs/generate.sh
+++ b/docs/generate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eou pipefail
 
-bazelisk build //docs:docs
+bazel build //docs:docs
 
 mv bazel-bin/docs/rule.md docs/rule.md
 

--- a/tests/integration/test_default_attributes.sh
+++ b/tests/integration/test_default_attributes.sh
@@ -2,11 +2,11 @@
 set -eou pipefail
 
 TARGET="detekt_with_default_attributes"
-OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
+OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration/"
 
 echo ":: Target with default attributes should generate text report."
 
-bazelisk build //tests/integration:${TARGET}
+bazel build //tests/integration:${TARGET}
 
 set -x
 

--- a/tests/integration/test_html_report.sh
+++ b/tests/integration/test_html_report.sh
@@ -2,11 +2,11 @@
 set -eou pipefail
 
 TARGET="detekt_html_report"
-OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
+OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration/"
 
 echo ":: Target with HTML report attribute should generate text and HTML reports."
 
-bazelisk build //tests/integration:${TARGET}
+bazel build //tests/integration:${TARGET}
 
 set -x
 

--- a/tests/integration/test_strict_config.sh
+++ b/tests/integration/test_strict_config.sh
@@ -4,7 +4,7 @@ set -eou pipefail
 echo ":: Target with strict config should fail."
 
 set +e
-bazelisk build //tests/integration:detekt_with_strict_config > /tmp/bazel.log > /dev/null
+bazel build //tests/integration:detekt_with_strict_config > /tmp/bazel.log > /dev/null
 BAZEL_EXIT_CODE=$?
 set -e
 

--- a/tests/integration/test_strict_config_baseline.sh
+++ b/tests/integration/test_strict_config_baseline.sh
@@ -2,11 +2,11 @@
 set -eou pipefail
 
 TARGET="detekt_with_strict_config_and_baseline"
-OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
+OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration/"
 
 echo ":: Target with strict config and baseline should not fail (like the baseline-less does) and should generate text report."
 
-bazelisk build //tests/integration:${TARGET}
+bazel build //tests/integration:${TARGET}
 
 set -x
 

--- a/tests/integration/test_strict_config_filegroup.sh
+++ b/tests/integration/test_strict_config_filegroup.sh
@@ -4,7 +4,7 @@ set -eou pipefail
 echo ":: Target with strict config filegroup should fail."
 
 set +e
-bazelisk build //tests/integration:detekt_with_strict_config_filegroup > /tmp/bazel.log > /dev/null
+bazel build //tests/integration:detekt_with_strict_config_filegroup > /tmp/bazel.log > /dev/null
 BAZEL_EXIT_CODE=$?
 set -e
 

--- a/tests/integration/test_strict_config_filegroup_baseline.sh
+++ b/tests/integration/test_strict_config_filegroup_baseline.sh
@@ -2,11 +2,11 @@
 set -eou pipefail
 
 TARGET="detekt_with_strict_config_filegroup_and_baseline"
-OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
+OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration/"
 
 echo ":: Target with strict config filegroup and baseline should not fail (like the baseline-less does) and should generate text report."
 
-bazelisk build //tests/integration:${TARGET}
+bazel build //tests/integration:${TARGET}
 
 set -x
 

--- a/tests/integration/test_xml_report.sh
+++ b/tests/integration/test_xml_report.sh
@@ -2,11 +2,11 @@
 set -eou pipefail
 
 TARGET="detekt_xml_report"
-OUTPUT_DIR="$(bazelisk info bazel-bin)/tests/integration/"
+OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration/"
 
 echo ":: Target with XML report attribute should generate text and XML reports."
 
-bazelisk build //tests/integration:${TARGET}
+bazel build //tests/integration:${TARGET}
 
 set -x
 


### PR DESCRIPTION
The cannonical Bazelisk usage [is to link it as `bazel`](https://github.com/bazelbuild/bazelisk#about-bazelisk). The Bazelisk formula in Homebrew doesn’t do that but the [Bazel tap](https://github.com/bazelbuild/homebrew-tap) one does. Let’s follow it there as well.

Sneaking a number of updates:

* [`actions/checkout`](https://github.com/actions/checkout/releases/tag/v2.0.0)
* [`actions/setup-java`](https://github.com/actions/setup-java/releases)
* [Bazelisk](https://github.com/bazelbuild/bazelisk/releases/tag/v1.2.0)