### PR TITLE
Change toolchain type to be public.

### DIFF
--- a/detekt/BUILD
+++ b/detekt/BUILD
@@ -2,6 +2,7 @@ load("//detekt:toolchain.bzl", "detekt_toolchain")
 
 toolchain_type(
     name = "toolchain_type",
+    visibility = ["//visibility:public"],
 )
 
 detekt_toolchain(


### PR DESCRIPTION
I have no idea how it slipped away from me, sorry. I specifically created a dedicated sandbox workspace to check toolchains from a rule user perspective but somehow I missed something.