### PR TITLE
Add GitHub Actions cache

### DIFF
--- a/.github/workflows/.bazelrc
+++ b/.github/workflows/.bazelrc
@@ -1,0 +1,10 @@
+common --curses=no
+
+build --verbose_failures
+build --worker_verbose
+
+build --repository_cache=.cache
+fetch --repository_cache=.cache
+query --repository_cache=.cache
+
+build --disk_cache=.cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,19 @@ jobs:
         run: |
           curl --location --fail "https://github.com/bazelbuild/bazelisk/releases/download/v${VERSION_BAZELISK}/bazelisk-linux-amd64" --output /tmp/bazel
           chmod +x /tmp/bazel && echo "::add-path::/tmp/"
+      - name: "Configure Bazel"
+        run: cp .github/workflows/.bazelrc .
+      - name: "Configure cache"
+        uses: actions/cache@v1.1.0
+        with:
+          path: .cache
+          key: ${{ runner.os }}-bazel-${{ hashFiles('WORKSPACE') }}
+          restore-keys: |
+            ${{ runner.os }}-bazel-
+      - name: "Fetch"
+        run: bazel fetch //detekt/wrapper:bin
+      - name: "Build"
+        run: bazel build //detekt/wrapper:bin
       - name: "Unit tests"
         run: bazel test //detekt/wrapper:tests
       - name: "Analysis tests"

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/main.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/main.kt
@@ -15,7 +15,7 @@ fun main(arguments: Array<String>) {
     val executable = Executable.DetektImpl(Detekt.Impl())
     val consoleStreams = Streams.system()
 
-    val application = if ("--persistent_worker" in arguments) {
+    val application = if ("--persistent_worker_" in arguments) {
         Application.Worker(Schedulers.io(), WorkerExecutable.Impl(executable), WorkerStreams.Impl(consoleStreams))
     } else {
         Application.OneShot(executable, consoleStreams, Platform.Impl())

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/main.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/main.kt
@@ -15,7 +15,7 @@ fun main(arguments: Array<String>) {
     val executable = Executable.DetektImpl(Detekt.Impl())
     val consoleStreams = Streams.system()
 
-    val application = if ("--persistent_worker_" in arguments) {
+    val application = if ("--persistent_worker" in arguments) {
         Application.Worker(Schedulers.io(), WorkerExecutable.Impl(executable), WorkerStreams.Impl(consoleStreams))
     } else {
         Application.OneShot(executable, consoleStreams, Platform.Impl())


### PR DESCRIPTION
Finally, we are not compiling the freaking Protocol Buffers compiler every time!

* [Run without cache](https://github.com/buildfoundation/bazel_rules_detekt/runs/389592392) — 6 minutes.
* [Run with cache](https://github.com/buildfoundation/bazel_rules_detekt/runs/389636325) — 2.5 minutes.

BTW, almost the entire thing was stolen from [TensorBoard](https://github.com/tensorflow/tensorboard) and adapted to Actions from Travis.