### PR TITLE
Add stdout to Detekt output on errors.

### DIFF
--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/Executable.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/Executable.kt
@@ -11,20 +11,25 @@ internal interface Executable {
     class DetektImpl(private val detekt: Detekt) : Executable {
 
         override fun execute(args: Array<String>): Result {
-            val outputPrinter = PrintStream(Streams.DevNullOutputStream().buffered())
+            val outputBuffer = ByteArrayOutputStream()
+            val outputPrinter = PrintStream(outputBuffer.buffered())
 
-            val errorPrinterBuffer = ByteArrayOutputStream()
-            val errorPrinter = PrintStream(errorPrinterBuffer.buffered())
+            val errorBuffer = ByteArrayOutputStream()
+            val errorPrinter = PrintStream(errorBuffer.buffered())
 
             return try {
                 detekt.execute(args, outputPrinter, errorPrinter)
 
                 Result.Success
             } catch (e: Exception) {
+                outputPrinter.flush()
+
                 e.printStackTrace(errorPrinter)
                 errorPrinter.flush()
 
-                Result.Failure(errorPrinterBuffer.toString(Charset.defaultCharset()))
+                Result.Failure(arrayOf(outputBuffer, errorBuffer).joinToString(separator = "") {
+                    it.toString(Charset.defaultCharset())
+                })
             } finally {
                 outputPrinter.close()
                 errorPrinter.close()


### PR DESCRIPTION
Closes #61.

Don’t quite get it why Detekt prints a bulk of errors to the output stream but oh well.

### Before

```console
$ bazel build //tests/integration:detekt_without_config 

INFO: Analyzed target //tests/integration:detekt_without_config (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
ERROR: bazel_rules_detekt/tests/integration/BUILD:8:1: Detekt tests/integration/detekt_without_config_detekt_report.txt failed (Exit 1)
io.gitlab.arturbosch.detekt.cli.BuildFailure: Build failed with 1 weighted issues (threshold defined was 0).
Target //tests/integration:detekt_without_config failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 3.513s, Critical Path: 3.27s
INFO: 1 process: 1 worker.
FAILED: Build did NOT complete successfully
```
### After

```console
$ bazel build //tests/integration:detekt_without_config 

INFO: Analyzed target //tests/integration:detekt_without_config (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
ERROR: bazel_rules_detekt/tests/integration/BUILD:8:1: Detekt tests/integration/detekt_without_config_detekt_report.txt failed (Exit 1)
empty-blocks - 5min debt
	EmptyFunctionBlock - [main] at /private/var/tmp/_bazel/d6e85247c27f29d694672a28ac6d18f5/execroot/rules_detekt/tests/integration/src/main/kotlin/io/buildfoundation/bazel/detekt/main.kt:3:31

Overall debt: 5min

io.gitlab.arturbosch.detekt.cli.BuildFailure: Build failed with 1 weighted issues (threshold defined was 0).
Target //tests/integration:detekt_without_config failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.545s, Critical Path: 0.31s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
```