### PR TITLE
Update JVM External rules 3.1 → 3.2

### DIFF
--- a/detekt/dependencies.bzl
+++ b/detekt/dependencies.bzl
@@ -40,8 +40,8 @@ def rules_detekt_dependencies():
 
     # JVM External
 
-    rules_jvm_external_version = "3.1"
-    rules_jvm_external_sha = "19c5c43a84d3c631a047b8e499b00b3ffca2e6784a1e4abfe2facdf865951e43"
+    rules_jvm_external_version = "3.2"
+    rules_jvm_external_sha = "19d402ef15f58750352a1a38b694191209ebc7f0252104b81196124fdd43ffa0"
 
     maybe(
         repo_rule = http_archive,

--- a/detekt/toolchains.bzl
+++ b/detekt/toolchains.bzl
@@ -6,6 +6,7 @@ See https://docs.bazel.build/versions/master/skylark/deploying.html#registering-
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
+load("@rules_jvm_external//:specs.bzl", "maven")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 
 def rules_detekt_toolchains(detekt_version = "1.8.0", toolchain = "@rules_detekt//detekt:default_toolchain"):
@@ -33,9 +34,9 @@ def rules_detekt_toolchains(detekt_version = "1.8.0", toolchain = "@rules_detekt
     maven_install(
         name = "rules_detekt_dependencies",
         artifacts = [
-            "io.gitlab.arturbosch.detekt:detekt-cli:{v}".format(v = detekt_version),
-            "io.reactivex.rxjava2:rxjava:2.2.16",
-            "junit:junit:4.12",
+            maven.artifact("io.gitlab.arturbosch.detekt", "detekt-cli", detekt_version),
+            maven.artifact("io.reactivex.rxjava2", "rxjava", "2.2.16"),
+            maven.artifact("junit", "junit", "4.12", testonly = True),
         ],
         repositories = [
             "https://repo1.maven.org/maven2",


### PR DESCRIPTION
[Changes](https://github.com/bazelbuild/rules_jvm_external/releases/tag/3.2).