### PR TITLE
Update RxJava 2.2.16 → 3.0.2

### DIFF
--- a/detekt/toolchains.bzl
+++ b/detekt/toolchains.bzl
@@ -35,7 +35,7 @@ def rules_detekt_toolchains(detekt_version = "1.8.0", toolchain = "@rules_detekt
         name = "rules_detekt_dependencies",
         artifacts = [
             maven.artifact("io.gitlab.arturbosch.detekt", "detekt-cli", detekt_version),
-            maven.artifact("io.reactivex.rxjava2", "rxjava", "2.2.16"),
+            maven.artifact("io.reactivex.rxjava3", "rxjava", "3.0.2"),
             maven.artifact("junit", "junit", "4.13", testonly = True),
         ],
         repositories = [

--- a/detekt/wrapper/BUILD
+++ b/detekt/wrapper/BUILD
@@ -18,7 +18,7 @@ kt_jvm_library(
     deps = [
         ":worker_protocol_java_proto",
         "@rules_detekt_dependencies//:io_gitlab_arturbosch_detekt_detekt_cli",
-        "@rules_detekt_dependencies//:io_reactivex_rxjava2_rxjava",
+        "@rules_detekt_dependencies//:io_reactivex_rxjava3_rxjava",
     ],
 )
 

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/Application.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/Application.kt
@@ -5,7 +5,7 @@ import io.buildfoundation.bazel.detekt.execute.Result
 import io.buildfoundation.bazel.detekt.execute.WorkerExecutable
 import io.buildfoundation.bazel.detekt.stream.Streams
 import io.buildfoundation.bazel.detekt.stream.WorkerStreams
-import io.reactivex.Scheduler
+import io.reactivex.rxjava3.core.Scheduler
 
 internal interface Application {
 

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/main.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/main.kt
@@ -7,7 +7,7 @@ import io.buildfoundation.bazel.detekt.execute.Executable
 import io.buildfoundation.bazel.detekt.execute.WorkerExecutable
 import io.buildfoundation.bazel.detekt.stream.Streams
 import io.buildfoundation.bazel.detekt.stream.WorkerStreams
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.schedulers.Schedulers
 
 /**
  * The wrapper purpose:

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/stream/WorkerStreams.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/stream/WorkerStreams.kt
@@ -2,10 +2,10 @@ package io.buildfoundation.bazel.detekt.stream
 
 import bazel.worker.WorkerProtocol.WorkRequest
 import bazel.worker.WorkerProtocol.WorkResponse
-import io.reactivex.BackpressureStrategy
-import io.reactivex.Flowable
-import io.reactivex.FlowableEmitter
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.core.BackpressureStrategy
+import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.core.FlowableEmitter
+import io.reactivex.rxjava3.functions.Consumer
 
 interface WorkerStreams {
 


### PR DESCRIPTION
[Changes](https://github.com/ReactiveX/RxJava/wiki/What's-different-in-3.0).

Seems like a major upgrade but not a lot of changes for us.