### PR TITLE
Fix integration tests suite error propagation

### DIFF
--- a/tests/integration/suite.sh
+++ b/tests/integration/suite.sh
@@ -15,7 +15,7 @@ for STRATEGY in "local" "worker"; do
 
     # Generate a bit of code to keep Bazel working instead of pulling from cache to check strategies execution.
     rm -rf "${GENERATED_CODE_DIR}" && mkdir -p "${GENERATED_CODE_DIR}"
-    touch "${GENERATED_CODE_DIR}/${STRATEGY}.kt"
+    echo '@file:Suppress("EmptyKtFile")' > "${GENERATED_CODE_DIR}/${STRATEGY}.kt"
 
     for TEST in tests/integration/test_*.sh; do
         bash $TEST

--- a/tests/integration/suite.sh
+++ b/tests/integration/suite.sh
@@ -17,7 +17,9 @@ for STRATEGY in "local" "worker"; do
     rm -rf "${GENERATED_CODE_DIR}" && mkdir -p "${GENERATED_CODE_DIR}"
     touch "${GENERATED_CODE_DIR}/${STRATEGY}.kt"
 
-    find "tests/integration" -type f -name "test_*.sh" -exec bash {} \;
+    for TEST in tests/integration/test_*.sh; do
+        bash $TEST
+    done
 
     rm -rf "${GENERATED_CODE_DIR}"
 done

--- a/tests/integration/test_baseline.sh
+++ b/tests/integration/test_baseline.sh
@@ -2,7 +2,7 @@
 set -eou pipefail
 
 TARGET="detekt_without_config_with_baseline"
-OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration/"
+OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration"
 
 echo ":: Target without config and with baseline should not fail and should generate text report."
 

--- a/tests/integration/test_config_file_lenient.sh
+++ b/tests/integration/test_config_file_lenient.sh
@@ -2,7 +2,7 @@
 set -eou pipefail
 
 TARGET="detekt_with_config_file_lenient"
-OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration/"
+OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration"
 
 echo ":: Target with lenient config file should not fail and should generate text report."
 

--- a/tests/integration/test_config_filegroup_lenient.sh
+++ b/tests/integration/test_config_filegroup_lenient.sh
@@ -2,7 +2,7 @@
 set -eou pipefail
 
 TARGET="detekt_with_config_filegroup_lenient"
-OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration/"
+OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration"
 
 echo ":: Target with lenient config file group should not fail and should generate text report."
 

--- a/tests/integration/test_report_html.sh
+++ b/tests/integration/test_report_html.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -eou pipefail
 
-TARGET="detekt_without_config_with_report_xml"
-OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration/"
+TARGET="detekt_without_config_with_report_html"
+OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration"
 
 echo ":: Target without config and with HTML report attribute should generate text and HTML reports."
 

--- a/tests/integration/test_report_text.sh
+++ b/tests/integration/test_report_text.sh
@@ -2,7 +2,7 @@
 set -eou pipefail
 
 TARGET="detekt_without_config"
-OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration/"
+OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration"
 
 echo ":: Target without config should fail and generate text report."
 

--- a/tests/integration/test_report_xml.sh
+++ b/tests/integration/test_report_xml.sh
@@ -2,7 +2,7 @@
 set -eou pipefail
 
 TARGET="detekt_without_config_with_report_xml"
-OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration/"
+OUTPUT_DIR="$(bazel info bazel-bin)/tests/integration"
 
 echo ":: Target without config and with XML report attribute should generate text and XML reports."
 


### PR DESCRIPTION
Fun — [`find` does not propagate execution errors](https://apple.stackexchange.com/q/49042).