### PR TITLE
Change GitHub Actions to run on master pushes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - "master"
 
 env:
   VERSION_BAZELISK: "1.4.0"
@@ -62,4 +66,3 @@ jobs:
 
       - name: "Integration tests"
         run: bash tests/integration/suite.sh
-


### PR DESCRIPTION
Running on all pushes doesn’t bring anything useful to the table at this point but duplicating runs. With this change runs will be done on PRs and on pushes to `master`.

PTAL @artem-zinnatullin @Kernald 