### PR TITLE
Update GitHub Actions tools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,15 +3,15 @@ name: CI
 on: [push, pull_request]
 
 env:
-  VERSION_BAZELISK: "1.4.0"
-  VERSION_BUILDIFIER: "2.2.1"
+  VERSION_BAZELISK: "1.5.0"
+  VERSION_BUILDIFIER: "3.3.0"
 
 jobs:
   buildifier:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout the source code"
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v2.3.1
 
       - name: "Download Buildifier"
         run: |
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout the source code"
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v2.3.1
 
       - name: "Install JDK"
         uses: actions/setup-java@v1.3.0
@@ -41,7 +41,7 @@ jobs:
         run: cp .github/workflows/.bazelrc .
 
       - name: "Configure cache"
-        uses: actions/cache@v1.1.2
+        uses: actions/cache@v2.0.0
         with:
           path: .cache
           key: ${{ runner.os }}-bazel-${{ hashFiles('WORKSPACE') }}

--- a/detekt/toolchains.bzl
+++ b/detekt/toolchains.bzl
@@ -9,6 +9,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@rules_jvm_external//:specs.bzl", "maven")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 
+# buildifier: disable=unnamed-macro
 def rules_detekt_toolchains(detekt_version = "1.8.0", toolchain = "@rules_detekt//detekt:default_toolchain"):
     """Invokes `rules_detekt` toolchains.
 


### PR DESCRIPTION
* [Bazelisk 1.4.0 → 1.5.0](https://github.com/bazelbuild/bazelisk/releases/tag/v1.5.0)
* [Bazel build tools 2.2.1 → 3.3.0](https://github.com/bazelbuild/buildtools/releases)
* [GitHub Actions checkout 2.1.0 → 2.3.1](https://github.com/actions/checkout/releases)
* [GitHub Actions cache 1.1.2 → 2.2.0](https://github.com/actions/cache/releases)