### PR TITLE
Fix GitHub Actions by switching away from add-path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           chmod +x /tmp/buildifier && echo "/tmp/" >> $GITHUB_PATH
 
       - name: "Lint Starlark files"
-        run: $GITHUB_WORKSPACE/bin/buildifier -mode check -lint warn -r .
+        run: buildifier -mode check -lint warn -r .
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,6 @@ on:
     branches:
       - "master"
 
-env:
-  VERSION_BAZELISK: "1.5.0"
-  VERSION_BUILDIFIER: "3.3.0"
-
 jobs:
   buildifier:
     runs-on: ubuntu-latest
@@ -19,11 +15,13 @@ jobs:
 
       - name: "Download Buildifier"
         run: |
-          curl --location --fail "https://github.com/bazelbuild/buildtools/releases/download/${VERSION_BUILDIFIER}/buildifier" --output /tmp/buildifier
-          chmod +x /tmp/buildifier && echo "::add-path::/tmp/"
+          curl -LO "https://github.com/bazelbuild/buildtools/releases/download/3.3.0/buildifier"
+          mkdir -p "${GITHUB_WORKSPACE}/bin/"
+          mv buildifier "${GITHUB_WORKSPACE}/bin/buildifier"
+          chmod +x "${GITHUB_WORKSPACE}/bin/buildifier"
 
       - name: "Lint Starlark files"
-        run: buildifier -mode check -lint warn -r .
+        run: $GITHUB_WORKSPACE/bin/buildifier -mode check -lint warn -r .
 
   build:
     runs-on: ubuntu-latest
@@ -38,8 +36,10 @@ jobs:
 
       - name: "Download Bazelisk"
         run: |
-          curl --location --fail "https://github.com/bazelbuild/bazelisk/releases/download/v${VERSION_BAZELISK}/bazelisk-linux-amd64" --output /tmp/bazel
-          chmod +x /tmp/bazel && echo "::add-path::/tmp/"
+          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.5.0/bazelisk-linux-amd64"
+          mkdir -p "${GITHUB_WORKSPACE}/bin/"
+          mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
+          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
 
       - name: "Configure Bazel"
         run: cp .github/workflows/.bazelrc .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,8 @@ jobs:
 
       - name: "Download Buildifier"
         run: |
-          curl -LO "https://github.com/bazelbuild/buildtools/releases/download/3.3.0/buildifier"
-          mkdir -p "${GITHUB_WORKSPACE}/bin/"
-          mv buildifier "${GITHUB_WORKSPACE}/bin/buildifier"
-          chmod +x "${GITHUB_WORKSPACE}/bin/buildifier"
+          curl --location --fail "https://github.com/bazelbuild/buildtools/releases/download/3.3.0/buildifier" --output /tmp/buildifier
+          chmod +x /tmp/buildifier && echo "/tmp/" >> $GITHUB_PATH
 
       - name: "Lint Starlark files"
         run: $GITHUB_WORKSPACE/bin/buildifier -mode check -lint warn -r .
@@ -36,10 +34,8 @@ jobs:
 
       - name: "Download Bazelisk"
         run: |
-          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.5.0/bazelisk-linux-amd64"
-          mkdir -p "${GITHUB_WORKSPACE}/bin/"
-          mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
-          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
+          curl --location --fail "https://github.com/bazelbuild/bazelisk/releases/download/v1.5.0/bazelisk-linux-amd64" --output /tmp/bazel
+          chmod +x /tmp/bazel && echo "/tmp/" >> $GITHUB_PATH
 
       - name: "Configure Bazel"
         run: cp .github/workflows/.bazelrc .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v2.3.1
 
       - name: "Install JDK"
-        uses: actions/setup-java@v1.3.0
+        uses: actions/setup-java@v1.4.3
         with:
           java-version: "11.0.5"
 


### PR DESCRIPTION
Github no long supports `set-env` and `add-path`. Github workflows will no longer work until we migrate away from these usages.