### PR TITLE
Update Kotlin rules 1.3.0 → 1.5.0-alpha3

### DIFF
--- a/detekt/dependencies.bzl
+++ b/detekt/dependencies.bzl
@@ -27,15 +27,15 @@ def rules_detekt_dependencies():
 
     # Stardoc
 
-    rules_java_version = "0.4.0"
-    rules_java_sha = "36b8d6c2260068b9ff82faea2f7add164bf3436eac9ba3ec14809f335346d66a"
+    rules_stardoc_version = "0.4.0"
+    rules_stardoc_sha = "36b8d6c2260068b9ff82faea2f7add164bf3436eac9ba3ec14809f335346d66a"
 
     maybe(
         repo_rule = http_archive,
         name = "io_bazel_stardoc",
-        sha256 = rules_java_sha,
-        strip_prefix = "stardoc-{}".format(rules_java_version),
-        url = "https://github.com/bazelbuild/stardoc/archive/{}.zip".format(rules_java_version),
+        sha256 = rules_stardoc_sha,
+        strip_prefix = "stardoc-{}".format(rules_stardoc_version),
+        url = "https://github.com/bazelbuild/stardoc/archive/{}.zip".format(rules_stardoc_version),
     )
 
     # Java

--- a/detekt/dependencies.bzl
+++ b/detekt/dependencies.bzl
@@ -5,7 +5,6 @@ See https://docs.bazel.build/versions/master/skylark/deploying.html#dependencies
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def rules_detekt_dependencies():
     """Fetches `rules_detekt` dependencies.

--- a/detekt/dependencies.bzl
+++ b/detekt/dependencies.bzl
@@ -33,7 +33,7 @@ def rules_detekt_dependencies():
     maybe(
         repo_rule = http_archive,
         name = "io_bazel_rules_kotlin",
-        url = "https://github.com/bazelbuild/rules_kotlin/releases/download/{}/rules_kotlin_release.tgz".format(rules_kotlin_version),
+        url = "https://github.com/bazelbuild/rules_kotlin/releases/download/v{}/rules_kotlin_release.tgz".format(rules_kotlin_version),
         sha256 = rules_kotlin_sha,
     )
 

--- a/detekt/dependencies.bzl
+++ b/detekt/dependencies.bzl
@@ -52,8 +52,8 @@ def rules_detekt_dependencies():
 
     # Kotlin
 
-    rules_kotlin_version = "1.5.0-alpha-1"
-    rules_kotlin_sha = "14d5fed813fd75105e7621f1b50a1aec2749906b62888d28acbb488ac5dfcca5"
+    rules_kotlin_version = "1.5.0-alpha-2"
+    rules_kotlin_sha = "6194a864280e1989b6d8118a4aee03bb50edeeae4076e5bc30eef8a98dcd4f07"
 
     maybe(
         repo_rule = http_archive,

--- a/detekt/dependencies.bzl
+++ b/detekt/dependencies.bzl
@@ -53,7 +53,7 @@ def rules_detekt_dependencies():
     # Kotlin
 
     rules_kotlin_version = "1.5.0-alpha-2"
-    rules_kotlin_sha = "6194a864280e1989b6d8118a4aee03bb50edeeae4076e5bc30eef8a98dcd4f07"
+    rules_kotlin_sha = "4bb069d76e490d873d6bc271d864d599490ab6c492edf270fcb1090ab11aa23c"
 
     maybe(
         repo_rule = http_archive,

--- a/detekt/dependencies.bzl
+++ b/detekt/dependencies.bzl
@@ -5,6 +5,7 @@ See https://docs.bazel.build/versions/master/skylark/deploying.html#dependencies
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def rules_detekt_dependencies():
     """Fetches `rules_detekt` dependencies.
@@ -12,6 +13,31 @@ def rules_detekt_dependencies():
     Declares dependencies of the `rules_detekt` workspace.
     Users should call this macro in their `WORKSPACE` file.
     """
+
+    # Pkg
+
+    rules_pkg_version = "0.2.4"
+    rules_pkg_sha = "4ba8f4ab0ff85f2484287ab06c0d871dcb31cc54d439457d28fd4ae14b18450a"
+
+    maybe(
+        http_archive,
+        name = "rules_pkg",
+        url = "https://github.com/bazelbuild/rules_pkg/releases/download/{v}/rules_pkg-{v}.tar.gz".format(v = rules_pkg_version),
+        sha256 = rules_pkg_sha,
+    )
+
+    # Stardoc
+
+    rules_java_version = "0.4.0"
+    rules_java_sha = "36b8d6c2260068b9ff82faea2f7add164bf3436eac9ba3ec14809f335346d66a"
+
+    maybe(
+        repo_rule = http_archive,
+        name = "io_bazel_stardoc",
+        sha256 = rules_java_sha,
+        strip_prefix = "stardoc-{}".format(rules_java_version),
+        url = "https://github.com/bazelbuild/stardoc/archive/{}.zip".format(rules_java_version),
+    )
 
     # Java
 
@@ -27,13 +53,13 @@ def rules_detekt_dependencies():
 
     # Kotlin
 
-    rules_kotlin_version = "legacy-1.3.0"
-    rules_kotlin_sha = "2ba27f0fa8305a28bc1b9b3a3f4e6b91064b3c0021365fa9344ba3af88657e1b"
+    rules_kotlin_version = "1.5.0-alpha-1"
+    rules_kotlin_sha = "14d5fed813fd75105e7621f1b50a1aec2749906b62888d28acbb488ac5dfcca5"
 
     maybe(
         repo_rule = http_archive,
         name = "io_bazel_rules_kotlin",
-        url = "https://github.com/bazelbuild/rules_kotlin/archive/{v}.tar.gz".format(v = rules_kotlin_version),
+        url = "https://github.com/bazelbuild/rules_kotlin/archive/v{}.tar.gz".format(rules_kotlin_version),
         strip_prefix = "rules_kotlin-{v}".format(v = rules_kotlin_version),
         sha256 = rules_kotlin_sha,
     )

--- a/detekt/dependencies.bzl
+++ b/detekt/dependencies.bzl
@@ -52,8 +52,8 @@ def rules_detekt_dependencies():
 
     # Kotlin
 
-    rules_kotlin_version = "1.5.0-alpha-2"
-    rules_kotlin_sha = "4bb069d76e490d873d6bc271d864d599490ab6c492edf270fcb1090ab11aa23c"
+    rules_kotlin_version = "1.5.0-alpha-3"
+    rules_kotlin_sha = "0b3b9fe1a07ef42abc715a25e44c07ac0650a8aa73e7836c1afbaad74e7cdc78"
 
     maybe(
         repo_rule = http_archive,

--- a/detekt/dependencies.bzl
+++ b/detekt/dependencies.bzl
@@ -13,31 +13,6 @@ def rules_detekt_dependencies():
     Users should call this macro in their `WORKSPACE` file.
     """
 
-    # Pkg
-
-    rules_pkg_version = "0.2.4"
-    rules_pkg_sha = "4ba8f4ab0ff85f2484287ab06c0d871dcb31cc54d439457d28fd4ae14b18450a"
-
-    maybe(
-        http_archive,
-        name = "rules_pkg",
-        url = "https://github.com/bazelbuild/rules_pkg/releases/download/{v}/rules_pkg-{v}.tar.gz".format(v = rules_pkg_version),
-        sha256 = rules_pkg_sha,
-    )
-
-    # Stardoc
-
-    rules_stardoc_version = "0.4.0"
-    rules_stardoc_sha = "36b8d6c2260068b9ff82faea2f7add164bf3436eac9ba3ec14809f335346d66a"
-
-    maybe(
-        repo_rule = http_archive,
-        name = "io_bazel_stardoc",
-        sha256 = rules_stardoc_sha,
-        strip_prefix = "stardoc-{}".format(rules_stardoc_version),
-        url = "https://github.com/bazelbuild/stardoc/archive/{}.zip".format(rules_stardoc_version),
-    )
-
     # Java
 
     rules_java_version = "0.1.1"
@@ -53,13 +28,12 @@ def rules_detekt_dependencies():
     # Kotlin
 
     rules_kotlin_version = "1.5.0-alpha-3"
-    rules_kotlin_sha = "0b3b9fe1a07ef42abc715a25e44c07ac0650a8aa73e7836c1afbaad74e7cdc78"
+    rules_kotlin_sha = "eeae65f973b70896e474c57aa7681e444d7a5446d9ec0a59bb88c59fc263ff62"
 
     maybe(
         repo_rule = http_archive,
         name = "io_bazel_rules_kotlin",
-        url = "https://github.com/bazelbuild/rules_kotlin/archive/v{}.tar.gz".format(rules_kotlin_version),
-        strip_prefix = "rules_kotlin-{v}".format(v = rules_kotlin_version),
+        url = "https://github.com/bazelbuild/rules_kotlin/releases/download/{}/rules_kotlin_release.tgz".format(rules_kotlin_version),
         sha256 = rules_kotlin_sha,
     )
 

--- a/detekt/toolchains.bzl
+++ b/detekt/toolchains.bzl
@@ -48,5 +48,8 @@ def rules_detekt_toolchains(detekt_version = "1.10.0", toolchain = "@rules_detek
         excluded_artifacts = [
             "org.jetbrains.kotlin:kotlin-reflect",
             "org.jetbrains.kotlin:kotlin-stdlib",
+            "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
+            "org.jetbrains.kotlin:kotlin-script-runtime",
+            "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
         ],
     )


### PR DESCRIPTION
This brings in support for Kotlin 1.4.x and required to use newer versions of Detekt.

Changes: https://github.com/bazelbuild/rules_kotlin/releases/tag/v1.5.0-alpha-3

Issue: https://github.com/buildfoundation/bazel_rules_detekt/issues/83