### PR TITLE
Update Detekt 1.10.0 → 1.15.0

### DIFF
--- a/detekt/toolchains.bzl
+++ b/detekt/toolchains.bzl
@@ -10,14 +10,14 @@ load("@rules_jvm_external//:specs.bzl", "maven")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 
 # buildifier: disable=unnamed-macro
-def rules_detekt_toolchains(detekt_version = "1.10.0", toolchain = "@rules_detekt//detekt:default_toolchain"):
+def rules_detekt_toolchains(detekt_version = "1.15.0", toolchain = "@rules_detekt//detekt:default_toolchain"):
     """Invokes `rules_detekt` toolchains.
 
     Declares toolchains that are dependencies of the `rules_detekt` workspace.
     Users should call this macro in their `WORKSPACE` file.
 
     Args:
-        detekt_version: "io.gitlab.arturbosch.detekt:detekt-cli" version used by rules.
+        detekt_version: "io.gitlab.arturbosch.detekt:detekt-tools" version used by rules.
         toolchain: `detekt_toolchain` used by rules.
     """
 
@@ -52,4 +52,5 @@ def rules_detekt_toolchains(detekt_version = "1.10.0", toolchain = "@rules_detek
             "org.jetbrains.kotlin:kotlin-script-runtime",
             "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
         ],
+        fetch_sources = True,
     )

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/execute/Detekt.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/execute/Detekt.kt
@@ -1,6 +1,6 @@
 package io.buildfoundation.bazel.detekt.execute
 
-import io.gitlab.arturbosch.detekt.cli.buildRunner
+import io.github.detekt.tooling.api.DetektCli
 import java.io.PrintStream
 
 interface Detekt {
@@ -10,7 +10,7 @@ interface Detekt {
     class Impl : Detekt {
 
         override fun execute(args: Array<String>, outputPrinter: PrintStream, errorPrinter: PrintStream) {
-            buildRunner(args, outputPrinter, errorPrinter).execute()
+            DetektCli.load().run(args = args, outputChannel = outputPrinter, errorChannel = errorPrinter)
         }
     }
 }

--- a/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/execute/Executable.kt
+++ b/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/detekt/execute/Executable.kt
@@ -28,7 +28,7 @@ interface Executable {
                 errorPrinter.flush()
 
                 Result.Failure(arrayOf(outputBuffer, errorBuffer).joinToString(separator = "") {
-                    it.toString(Charset.defaultCharset())
+                    String(it.toByteArray(), Charset.defaultCharset())
                 })
             } finally {
                 outputPrinter.close()

--- a/detekt/wrapper/src/testFixtures/kotlin/io/buildfoundation/bazel/detekt/TestPlatform.kt
+++ b/detekt/wrapper/src/testFixtures/kotlin/io/buildfoundation/bazel/detekt/TestPlatform.kt
@@ -1,7 +1,5 @@
 package io.buildfoundation.bazel.detekt
 
-import io.buildfoundation.bazel.detekt.Platform
-
 internal class TestPlatform : Platform {
 
     var exitCode = Int.MIN_VALUE

--- a/detekt/wrapper/src/testFixtures/kotlin/io/buildfoundation/bazel/detekt/execute/TestExecutable.kt
+++ b/detekt/wrapper/src/testFixtures/kotlin/io/buildfoundation/bazel/detekt/execute/TestExecutable.kt
@@ -1,8 +1,5 @@
 package io.buildfoundation.bazel.detekt.execute
 
-import io.buildfoundation.bazel.detekt.execute.Executable
-import io.buildfoundation.bazel.detekt.execute.Result
-
 internal class TestExecutable(private val result: Result) : Executable {
 
     override fun execute(args: Array<String>) = result


### PR DESCRIPTION
What changed
- Switched away from `io.gitlab.arturbosch.detekt:detekt-cli` to `io.gitlab.arturbosch.detekt:detekt-tooling` to use the new `DetektCli` APIs
- Switched the baked in version of Detekt from `1.10.0` to `1.15.0`

Release notes for Detekt: https://detekt.github.io/detekt/changelog.html

This will likely need to merge first https://github.com/buildfoundation/bazel_rules_detekt/pull/89