### PR TITLE
Update RxJava 3.0.6 → 3.0.9

### DIFF
--- a/detekt/toolchains.bzl
+++ b/detekt/toolchains.bzl
@@ -37,7 +37,7 @@ def rules_detekt_toolchains(detekt_version = "1.15.0", toolchain = "@rules_detek
         artifacts = [
             maven.artifact("io.gitlab.arturbosch.detekt", "detekt-cli", detekt_version),
             maven.artifact("io.gitlab.arturbosch.detekt", "detekt-formatting", detekt_version),
-            maven.artifact("io.reactivex.rxjava3", "rxjava", "3.0.6"),
+            maven.artifact("io.reactivex.rxjava3", "rxjava", "3.0.9"),
             # TODO: rollback "testonly = true" once JVM External resolves transitive test dependencies properly.
             maven.artifact("junit", "junit", "4.13"),
         ],


### PR DESCRIPTION
[Changes](https://github.com/ReactiveX/RxJava/releases)