### PR TITLE
Update Buildifier 3.5.0 → 4.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   VERSION_BAZELISK: "1.7.4"
-  VERSION_BUILDIFIER: "3.5.0"
+  VERSION_BUILDIFIER: "4.0.0"
 
 jobs:
   buildifier:


### PR DESCRIPTION
[Changes](https://github.com/bazelbuild/buildtools/releases/tag/4.0.0)