### PR TITLE
Enable multiplex worker execution

### DIFF
--- a/detekt/defs.bzl
+++ b/detekt/defs.bzl
@@ -72,7 +72,7 @@ def _impl(ctx):
         executable = ctx.executable._detekt_wrapper,
         execution_requirements = {
             "supports-workers": "1",
-            "supports-multiplex-workers": "0",
+            "supports-multiplex-workers": "1",
         },
         arguments = [java_arguments, detekt_arguments],
     )

--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/Application.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/Application.java
@@ -51,7 +51,11 @@ public interface Application {
         public void run(String[] args) {
             streams.request()
                 .subscribeOn(scheduler)
+                .parallel()
+                .runOn(scheduler)
                 .map(executable::execute)
+                .sequential()
+                .observeOn(scheduler)
                 .blockingSubscribe(streams.response());
         }
     }


### PR DESCRIPTION
Results from MacBook Pro (2.4 GHz 8-core CPU, 32 GB RAM). No cache, clean builds on 3000+ targets. Values are average values from 3 consecutive runs.

|Execution   |Total, seconds (from CLI)|Detekt, seconds (from trace)|
|------------|-------------------------|-----------------------------|
|Singleplex   | 149.73                              | 100.40                                    |
|Multiplex     | 89.39                                | 39.99                                      |

CC @Bencodes 