### PR TITLE
Replace host with exec

### DIFF
--- a/detekt/defs.bzl
+++ b/detekt/defs.bzl
@@ -85,7 +85,7 @@ detekt = rule(
         "_detekt_wrapper": attr.label(
             default = "//detekt/wrapper:bin",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "srcs": attr.label_list(
             mandatory = True,


### PR DESCRIPTION
The host option is now deprecated and should be replaced with exec.