### PR TITLE
Switch to Zulu JDK, setup-bazelisk, and buildifier_prebuilt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,47 +6,38 @@ on:
     branches:
       - "master"
 
-env:
-  VERSION_BAZELISK: "1.7.4"
-  VERSION_BUILDIFIER: "4.0.0"
-
 jobs:
   buildifier:
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout the source code"
-        uses: actions/checkout@v2.3.4
-
-      - name: "Download Buildifier"
-        run: |
-          curl --location --fail "https://github.com/bazelbuild/buildtools/releases/download/${VERSION_BUILDIFIER}/buildifier" --output /tmp/buildifier
-          chmod +x /tmp/buildifier && echo "/tmp/" >> $GITHUB_PATH
-
-      - name: "Lint Starlark files"
-        run: buildifier -mode check -lint warn -r .
-
+      - name: "Checkout the sources"
+        uses: actions/checkout@v2.3.1
+      - name: "Install JDK 11"
+        uses: actions/setup-java@v2
+        with:
+          distribution: "zulu"
+          java-version: "11"
+      - name: "Setup Bazelisk"
+        uses: bazelbuild/setup-bazelisk@v1
+      - name: "Linting Starlark"
+        run: bazel run @buildifier_prebuilt//:buildifier -- -mode check -lint warn -r .
       - name: "Lint Shell files"
         run: for file in $(find . -type f -name "*.sh"); do shellcheck $file; done;
 
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout the source code"
-        uses: actions/checkout@v2.3.4
-
-      - name: "Install JDK"
-        uses: actions/setup-java@v1.4.3
+      - name: "Checkout the sources"
+        uses: actions/checkout@v2.3.1
+      - name: "Install JDK 11"
+        uses: actions/setup-java@v2
         with:
-          java-version: "11.0.5"
-
-      - name: "Download Bazelisk"
-        run: |
-          curl --location --fail "https://github.com/bazelbuild/bazelisk/releases/download/v${VERSION_BAZELISK}/bazelisk-linux-amd64" --output /tmp/bazel
-          chmod +x /tmp/bazel && echo "/tmp/" >> $GITHUB_PATH
-
+          distribution: "zulu"
+          java-version: "11"
+      - name: "Setup Bazelisk"
+        uses: bazelbuild/setup-bazelisk@v1
       - name: "Configure Bazel"
         run: cp .github/workflows/.bazelrc .
-
       - name: "Configure cache"
         uses: actions/cache@v2.1.3
         with:
@@ -54,18 +45,13 @@ jobs:
           key: ${{ runner.os }}-bazel-${{ hashFiles('WORKSPACE') }}
           restore-keys: |
             ${{ runner.os }}-bazel-
-
       - name: "Fetch"
         run: bazel fetch //detekt/wrapper:bin
-
       - name: "Build"
         run: bazel build //detekt/wrapper:bin
-
       - name: "Unit tests"
         run: bazel test //detekt/wrapper:tests
-
       - name: "Analysis tests"
         run: bazel test //tests/analysis:tests
-
       - name: "Integration tests"
         run: bash tests/integration/suite.sh

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,3 +52,22 @@ http_archive(
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
+
+# Linting
+
+## Buildifier
+
+http_archive(
+    name = "buildifier_prebuilt",
+    sha256 = "b3fd85ae7e45c2f36bce52cfdbdb6c20261761ea5928d1686edc8873b0d0dad0",
+    strip_prefix = "buildifier-prebuilt-5.1.0",
+    url = "http://github.com/keith/buildifier-prebuilt/archive/5.1.0.tar.gz",
+)
+
+load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
+
+buildifier_prebuilt_deps()
+
+load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
+
+buildifier_prebuilt_register_toolchains()


### PR DESCRIPTION
A few notable changes in this PR:
- Switches over to Zulu JDK 11
- Switches to `bazelbuild/setup-bazelisk` to install Bazelisk instead of using curl to manually download and install
- Switches to `buildifier_prebuilt` for linting starlark instead of installing buildifier using curl