### PR TITLE
Update Detekt 1.21.0 → 1.22.0

### DIFF
--- a/detekt/toolchains.bzl
+++ b/detekt/toolchains.bzl
@@ -8,7 +8,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@rules_jvm_external//:specs.bzl", "maven")
 
 # buildifier: disable=unnamed-macro
-def rules_detekt_toolchains(detekt_version = "1.21.0", toolchain = "@rules_detekt//detekt:default_toolchain"):
+def rules_detekt_toolchains(detekt_version = "1.22.0", toolchain = "@rules_detekt//detekt:default_toolchain"):
     """Invokes `rules_detekt` toolchains.
 
     Declares toolchains that are dependencies of the `rules_detekt` workspace.


### PR DESCRIPTION
Detekt Release Notes https://github.com/detekt/detekt/releases/tag/v1.22.0

Note: Detekt has added [Detekt Marketplace](https://detekt.dev/marketplace/) for 3rd-party rules, so far `rules_detekt` doesn't offer an API to easily integrate these, I've filed a tracking issue for that https://github.com/buildfoundation/bazel_rules_detekt/issues/134