### PR TITLE
Add back missing WORKSPACE test dependency

### DIFF
--- a/detekt/toolchains.bzl
+++ b/detekt/toolchains.bzl
@@ -31,6 +31,7 @@ def rules_detekt_toolchains(toolchain = "@rules_detekt//detekt:default_toolchain
             maven.artifact("com.squareup.okio", "okio-jvm", "3.2.0"),
             maven.artifact("io.reactivex.rxjava3", "rxjava", "3.0.12"),
             maven.artifact("junit", "junit", "4.13.2", testonly = True),
+            maevn.artifact("io.gitlab.arturbosch.detekt", "detekt-cli", "1.22.0", testonly = True),
         ],
         repositories = [
             "https://repo1.maven.org/maven2",


### PR DESCRIPTION
This dependency got dropped during the migration