### PR TITLE
Don't build manual targets on CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,1 @@
 common --enable_bzlmod
-
-try-import %workspace%/ci.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,4 @@
 common --enable_bzlmod
+common --test_tag_filters=-manual
 
 try-import %workspace%/ci.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,3 @@
 common --enable_bzlmod
+
+try-import %workspace%/ci.bazelrc

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -2,6 +2,7 @@
 # It is referenced with a --bazelrc option in the call to bazel in ci.yaml
 common --curses=no
 common --enable_bzlmod
+common --test_tag_filters=-manual
 
 build --verbose_failures
 build --worker_verbose

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -2,7 +2,6 @@
 # It is referenced with a --bazelrc option in the call to bazel in ci.yaml
 common --curses=no
 common --enable_bzlmod
-common --test_tag_filters=-manual
 
 build --verbose_failures
 build --worker_verbose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,9 +40,7 @@ jobs:
         run: cp .github/workflows/ci.bazelrc .
       - name: "Build"
         run: bazel build //detekt/wrapper:bin
-      - name: "Unit tests"
-        run: bazel test //detekt/wrapper:tests
       - name: "Analysis tests"
-        run: bazel test //tests/analysis:tests
+        run: bazel test //...
       - name: "Integration tests"
         run: bash tests/integration/suite.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,6 @@ jobs:
       - name: "Build"
         run: bazel build //detekt/wrapper:bin
       - name: "Unit tests"
-        run: bazel test //detekt/wrapper:tests
-      - name: "Analysis tests"
-        run: bazel test //tests/analysis:tests
+        run: bazel test //...
       - name: "Integration tests"
         run: bash tests/integration/suite.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,9 @@ jobs:
         run: cp .github/workflows/ci.bazelrc .
       - name: "Build"
         run: bazel build //detekt/wrapper:bin
+      - name: "Unit tests"
+        run: bazel test //detekt/wrapper:tests
       - name: "Analysis tests"
-        run: bazel test //...
+        run: bazel test //tests/analysis:tests
       - name: "Integration tests"
         run: bash tests/integration/suite.sh

--- a/tests/analysis/tests.bzl
+++ b/tests/analysis/tests.bzl
@@ -108,6 +108,7 @@ def _test_action_full_contents():
         parallel = True,
         # The "plugins" option is skipped here since the path includes a declared Detekt version
         # and we do not want to change the test every time the Detekt artifact is updated.
+        tags = ["manual"],
     )
 
     action_full_contents_test(
@@ -157,6 +158,7 @@ def _test_action_blank_contents():
     detekt(
         name = "test_target_blank",
         srcs = ["path A.kt", "path B.kt", "path C.kt"],
+        tags = ["manual"],
     )
 
     action_blank_contents_test(

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -3,22 +3,26 @@ load("//detekt:defs.bzl", "detekt")
 filegroup(
     name = "detekt_config_lenient",
     srcs = ["detekt_config_lenient.yml"],
+    tags = ["manual"],
 )
 
 detekt(
     name = "detekt_without_config",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
+    tags = ["manual"],
 )
 
 detekt(
     name = "detekt_without_config_with_report_html",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     html_report = True,
+    tags = ["manual"],
 )
 
 detekt(
     name = "detekt_without_config_with_report_xml",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
+    tags = ["manual"],
     xml_report = True,
 )
 
@@ -26,12 +30,14 @@ detekt(
     name = "detekt_without_config_with_baseline",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     baseline = "detekt_baseline.xml",
+    tags = ["manual"],
 )
 
 detekt(
     name = "detekt_without_config_with_baseline_with_plugin",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     baseline = "detekt_baseline.xml",
+    tags = ["manual"],
     plugins = ["@rules_detekt_dependencies//:io_gitlab_arturbosch_detekt_detekt_formatting"],
 )
 
@@ -39,10 +45,12 @@ detekt(
     name = "detekt_with_config_file_lenient",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     cfgs = ["detekt_config_lenient.yml"],
+    tags = ["manual"],
 )
 
 detekt(
     name = "detekt_with_config_filegroup_lenient",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     cfgs = ["//tests/integration:detekt_config_lenient"],
+    tags = ["manual"],
 )


### PR DESCRIPTION
Some of the rules_detekt targets aren't supposed to actually be built as part of CI and will just produce errors.

To support `//...` i'm going to mark the targets that are used for test scenarios as `manual` and set `--test_tag_filters=-manual` in the default bazelrc so that these targets are skipped over while looking for tests to evaluate.

Long term this rule set should just move over to https://github.com/bazel-contrib/rules_bazel_integration_test