### PR TITLE
Update Bzlmod presubmit to use //...

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -10,7 +10,6 @@ tasks:
     test_flags:
       - "--enable_bzlmod=true"
     build_targets:
-      - "//detekt/wrapper:bin"
+      - "//..."
     test_targets:
-      - "//detekt/wrapper:tests"
-      - "//tests/analysis:tests"
+      - "//..."

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -10,6 +10,6 @@ tasks:
     test_flags:
       - "--enable_bzlmod=true"
     build_targets:
-      - "//..."
+      - "@rules_detekt//..."
     test_targets:
-      - "//..."
+      - "@rules_detekt//..."


### PR DESCRIPTION
We can just build and test everything with this change https://github.com/buildfoundation/bazel_rules_detekt/commit/c6562c07af3cccc6838e24a2e5829a19956e6ea8

Related the presubmit fails in it's current state because it can't find the :bin target. https://buildkite.com/bazel/bcr-presubmit/builds/2135#018afeb5-b25c-4c52-b097-ad77e35e1d6f/256-268