### PR TITLE
Update rules_java to 5.5.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ register_toolchains("//detekt:default_toolchain")
 detekt = use_extension("//detekt:extensions.bzl", "detekt")
 use_repo(detekt, "detekt_cli_all")
 
-bazel_dep(name = "rules_java", version = "5.4.1")
+bazel_dep(name = "rules_java", version = "5.5.0")
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
 bazel_dep(name = "rules_jvm_external", version = "5.3")
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")

--- a/detekt/dependencies.bzl
+++ b/detekt/dependencies.bzl
@@ -40,8 +40,8 @@ def rules_detekt_dependencies(detekt = _DEFAULT_DETEKT_VERSION):
 
     # Java
 
-    rules_java_version = "5.4.1"
-    rules_java_sha = "a1f82b730b9c6395d3653032bd7e3a660f9d5ddb1099f427c1e1fe768f92e395"
+    rules_java_version = "5.5.0"
+    rules_java_sha = "bcfabfb407cb0c8820141310faa102f7fb92cc806b0f0e26a625196101b0b57e"
 
     maybe(
         repo_rule = http_archive,


### PR DESCRIPTION
Updating rules_java to resolve this warning:
```
WARNING: For repository 'rules_java', the root module requires module version rules_java@5.4.1, but got rules_java@5.5.0 in the resolved dependency graph.
```