### PR TITLE
Run only the /detekt/... tests during BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -10,6 +10,6 @@ tasks:
     test_flags:
       - "--enable_bzlmod=true"
     build_targets:
-      - "@rules_detekt//..."
+      - "@rules_detekt//detekt/..."
     test_targets:
-      - "@rules_detekt//..."
+      - "@rules_detekt//detekt/..."


### PR DESCRIPTION
Narrowing the build and test scope some so that we can get the BCR pre submit tests passing so that this can get deployed to the BCR.

Long term these rules need some e2e tests that we can have the presubmit properly run.

https://buildkite.com/bazel/bcr-presubmit/builds/2139#018b03ae-46bc-4477-abcc-d4ec798c9111