### PR TITLE
adding support for creating detekt baseline file

### DIFF
--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/execute/Detekt.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/execute/Detekt.java
@@ -2,7 +2,12 @@ package io.buildfoundation.bazel.detekt.execute;
 
 import io.gitlab.arturbosch.detekt.cli.CliRunner;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
 
 public interface Detekt {
 
@@ -18,6 +23,35 @@ public interface Detekt {
 
             if (resultError != null) {
                 throw resultError;
+            } else {
+                List<String> argsList = Arrays.asList(args);
+                if (argsList.contains("--create-baseline")) {
+                    String baseline = argsList.get(argsList.indexOf("--baseline") + 1);
+                    File baselineFile = new File(baseline);
+                    if (!baselineFile.exists()) {
+                        try {
+                            createEmptyBaseline(baselineFile);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+            }
+        }
+
+        String emptyBaseLineContent = "<?xml version=\"1.0\" ?>\n" +
+                "<SmellBaseline>\n" +
+                "  <ManuallySuppressedIssues></ManuallySuppressedIssues>\n" +
+                "  <CurrentIssues>\n" +
+                "  </CurrentIssues>\n" +
+                "</SmellBaseline>\n";
+
+        private void createEmptyBaseline(File baselineFile) throws IOException {
+            baselineFile.createNewFile();
+            try (FileWriter writer = new FileWriter(baselineFile)) {
+                writer.write(emptyBaseLineContent);
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         }
     }

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -7,6 +7,9 @@ Name           | Type                               | Default            | Descr
 `name` | [`name`](https://docs.bazel.build/versions/master/build-ref.html#name) | — | A unique name for this target.
 `baseline` | [`Label`](https://docs.bazel.build/versions/master/skylark/lib/Label.html) | `None` | [Detekt baseline file](https://detekt.github.io/detekt/baseline.html).
 `build_upon_default_config` | [`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html) | `False` | See [Detekt `--build-upon-default-config` option](https://detekt.github.io/detekt/cli.html).
+`auto_correct` | [`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html) | `False` | See [Detekt `auto_correct` option](https://detekt.github.io/detekt/cli.html).
+`disable_default_rule_sets` | [`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html) | `False` | See [Detekt `disable_default_rule_sets` option](https://detekt.github.io/detekt/cli.html).
+`all_rules` | [`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html) | `False` | See [Detekt `all_rules` option](https://detekt.github.io/detekt/cli.html).
 `cfgs` | [`[Label]`](https://docs.bazel.build/versions/master/skylark/lib/list.html) | `[]` | [Detekt configuration files](https://detekt.github.io/detekt/configurations.html). Otherwise [the default configuration](https://github.com/detekt/detekt/blob/master/detekt-core/src/main/resources/default-detekt-config.yml) is used.
 `disable_default_rulesets` | [`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html) | `False` | See [Detekt `--disable-default-rulesets` option](https://detekt.github.io/detekt/cli.html).
 `fail_fast` | [`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html) | `False` | See [Detekt `--fail-fast` option](https://detetk.github.io/detekt/cli.html).
@@ -15,4 +18,3 @@ Name           | Type                               | Default            | Descr
 `plugins` | [`[Label]`](https://docs.bazel.build/versions/master/skylark/lib/list.html) | `[]` | [Detekt plugins](https://detekt.github.io/detekt/extensions.html). For example, [the formatting rule set](https://detekt.github.io/detekt/formatting.html). Labels should be JVM artifacts (generated via [`rules_jvm_external`](https://github.com/bazelbuild/rules_jvm_external) work).
 `srcs` | [`[Label]`](https://docs.bazel.build/versions/master/skylark/lib/list.html) | — | Kotlin source code files.
 `xml_report` | [`bool`](https://docs.bazel.build/versions/master/skylark/lib/bool.html) | `False` | Enables / disables the XML report generation. The report file name is `{target_name}_detekt_report.xml`. FYI Detekt uses the Checkstyle XML reporting format which makes it compatible with tools like SonarQube.
-


### PR DESCRIPTION
adding support for creating detekt baseline file

    detekt_create_baseline(
        name = "detekt_create_baseline",
        srcs = srcs,
        plugins = plugins,
    )

then run 

    bazel run {detekt-target-name}