### PR TITLE
Integrate rules_pmd

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,1 +1,4 @@
-exports_files(["maven_install.json"])
+exports_files([
+    "maven_install.json",
+    "pmd_ruleset.xml",
+])

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,3 +31,4 @@ use_repo(maven, "rules_detekt_dependencies", "unpinned_rules_detekt_dependencies
 bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
+bazel_dep(name = "rules_pmd", version = "0.4.0", dev_dependency = True)

--- a/detekt/wrapper/BUILD
+++ b/detekt/wrapper/BUILD
@@ -1,4 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
+load("@rules_pmd//pmd:defs.bzl", "pmd_test")
 
 java_library(
     name = "wrapper",
@@ -7,6 +8,12 @@ java_library(
         "@bazel_worker_java//src/main/java/com/google/devtools/build/lib/worker:work_request_handlers",
         "@detekt_cli_all//jar",
     ],
+)
+
+pmd_test(
+    name = "wrapper_pmd_test",
+    srcs = glob(["src/main/java/**/*.java"]),
+    rulesets = ["//:pmd_ruleset.xml"],
 )
 
 java_binary(
@@ -27,4 +34,13 @@ java_test(
         ":wrapper",
         "@rules_detekt_dependencies//:junit_junit",
     ],
+)
+
+pmd_test(
+    name = "tests_pmd_test",
+    srcs = glob([
+        "src/test/java/**/*.java",
+        "src/testFixtures/java/**/*.java",
+    ]),
+    rulesets = ["//:pmd_ruleset.xml"],
 )

--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/ExecutionUtils.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/ExecutionUtils.java
@@ -1,11 +1,8 @@
 package io.buildfoundation.bazel.detekt;
 
-import java.io.BufferedWriter;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/detekt/wrapper/src/test/java/io/buildfoundation/bazel/detekt/ExecutionUtilsTests.java
+++ b/detekt/wrapper/src/test/java/io/buildfoundation/bazel/detekt/ExecutionUtilsTests.java
@@ -6,7 +6,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ExecutionUtilsTests {
 

--- a/pmd_ruleset.xml
+++ b/pmd_ruleset.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<ruleset name="rules_detekt-pmd-ruleset"
+  xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+  <description>PMD ruleset for rules_detekt Java code</description>
+
+  <!-- Best Practices -->
+  <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP" />
+  <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />
+  <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
+  <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />
+
+  <!-- Code Style -->
+  <rule ref="category/java/codestyle.xml/UnnecessaryImport" />
+  <rule ref="category/java/codestyle.xml/EmptyControlStatement" />
+
+  <!-- Design -->
+  <rule ref="category/java/design.xml/CollapsibleIfStatements" />
+  <rule ref="category/java/design.xml/SimplifiedTernary" />
+
+  <!-- Error Prone -->
+  <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop" />
+  <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor" />
+  <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators" />
+  <rule ref="category/java/errorprone.xml/BrokenNullCheck" />
+  <rule ref="category/java/errorprone.xml/ClassCastExceptionWithToArray" />
+  <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices" />
+  <rule ref="category/java/errorprone.xml/EmptyCatchBlock" />
+  <rule ref="category/java/errorprone.xml/JumbledIncrementer" />
+  <rule ref="category/java/errorprone.xml/MisplacedNullCheck" />
+  <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode" />
+  <rule ref="category/java/errorprone.xml/ReturnFromFinallyBlock" />
+  <rule ref="category/java/errorprone.xml/UnconditionalIfStatement" />
+
+  <!-- Performance -->
+  <rule ref="category/java/performance.xml/BigIntegerInstantiation" />
+  <rule ref="category/java/performance.xml/StringInstantiation" />
+
+  <!-- Security -->
+  <rule ref="category/java/security.xml/HardCodedCryptoKey" />
+  <rule ref="category/java/security.xml/InsecureCryptoIv" />
+
+</ruleset>


### PR DESCRIPTION
Doing some rules_pmd validation on the Java code in these rules. At some point we should consider just moving this over to Kotlin. 

For historical context, rules_kotlin at one point wasn't being actively maintained and it was causing some issues when being used in rule sets. Because of this, we wound up writing these files in Java.