### PR TITLE
Add support for custom URL templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ load("@rules_detekt//detekt:toolchains.bzl", "rules_detekt_toolchains")
 rules_detekt_toolchains()
 ```
 
-### bazelrc Configuration
+### `bazelrc` Configuration
 
 Users on Bazel releases prior to 5.1.0 need to enable the JSON Persistent Worker protocol in their `.bazelrc` like so:
 
@@ -80,22 +80,40 @@ $ bazel build //mypackage:my_detekt
 
 Results will be cached on successful runs.
 
-### Advanced Configuration
+## Advanced Configuration
 
-#### Detekt Version
+### Detekt Version
+
+#### `MODULE.bazel` Configuration
 
 Change the `MODULE.bazel` file:
 
 ```python
-detekt = use_extension("//detekt:extensions.bzl", "detekt")
+detekt = use_extension("@rules_detekt//detekt:extensions.bzl", "detekt")
 detekt.detekt_version(
     version = "x.x.x",
     sha256 = "x.x.x.sha256",
 )
+
 use_repo(detekt, "detekt_cli_all")
 ```
 
-Or change the `WORKSPACE` file:
+To download Detekt from a custom location (e.g. an internal mirror), use the `url_templates` parameter:
+
+```python
+detekt = use_extension("@rules_detekt//detekt:extensions.bzl", "detekt")
+detekt.detekt_version(
+    version = "x.x.x",
+    sha256 = "x.x.x.sha256",
+    url_templates = [
+        "https://my-mirror.example.com/detekt/detekt-cli-{version}-all.jar",
+    ],
+)
+
+use_repo(detekt, "detekt_cli_all")
+```
+
+#### `WORKSPACE` Configuration
 
 ```python
 load("@rules_detekt//detekt:versions.bzl", "detekt_version")
@@ -109,7 +127,23 @@ rules_detekt_dependencies(
 )
 ```
 
-#### JVM Flags
+To download Detekt from a custom location (e.g. an internal mirror), use the `url_templates` parameter:
+
+```python
+rules_detekt_dependencies(
+    detekt_version = detekt_version(
+        version = "x.x.x",
+        sha256 = "x.x.x.sha256",
+        url_templates = [
+            "https://my-mirror.example.com/detekt/detekt-cli-{version}-all.jar",
+        ],
+    )
+)
+```
+
+Each template may contain `{version}`, which will be replaced with the version string.
+
+### JVM Flags
 
 Define a toolchain in a `BUILD` file:
 

--- a/detekt/extensions.bzl
+++ b/detekt/extensions.bzl
@@ -15,6 +15,7 @@ _version_tag = tag_class(
     attrs = {
         "version": attr.string(mandatory = True),
         "sha256": attr.string(mandatory = True),
+        "url_templates": attr.string_list(),
     },
 )
 
@@ -31,7 +32,11 @@ def _detekt_impl(mctx):
         for override in mod.tags.detekt_version:
             if detekt_version:
                 fail("Only a single detekt_version at once is supported right now!")
-            detekt_version = _detekt_version(version = override.version, sha256 = override.sha256)
+            detekt_version = _detekt_version(
+                version = override.version,
+                sha256 = override.sha256,
+                url_templates = override.url_templates if override.url_templates else None,
+            )
 
     kwargs = dict(detekt = _DEFAULT_DETEKT_RELEASE)
     if detekt_version:

--- a/detekt/versions.bzl
+++ b/detekt/versions.bzl
@@ -1,21 +1,26 @@
 """Macro for defining detekt versions.
 """
 
-def detekt_version(version, sha256):
+_DEFAULT_URL_TEMPLATES = [
+    "https://github.com/detekt/detekt/releases/download/v{version}/detekt-cli-{version}-all.jar",
+]
+
+def detekt_version(version, sha256, url_templates = None):
     """Create a detekt version.
 
     Args:
         version (str): The version of detekt.
         sha256 (str): The sha256 of the detekt jar.
+        url_templates (list, optional): URL templates for downloading detekt. Each template
+            may contain `{version}` which will be replaced with the version string.
+            Defaults to the standard GitHub release URL.
 
     Returns: A struct containing the version information.
     """
     return struct(
         version = version,
         sha256 = sha256,
-        url_templates = [
-            "https://github.com/detekt/detekt/releases/download/v{version}/detekt-cli-{version}-all.jar",
-        ],
+        url_templates = url_templates if url_templates != None else _DEFAULT_URL_TEMPLATES,
     )
 
 DEFAULT_DETEKT_RELEASE = detekt_version(


### PR DESCRIPTION
This adds a `url_templates` parameter for Detekt versions so callers can override the default download URL. This makes it easy to point Detekt artifact fetches at internal mirrors or alternate repositories improving reliability in restricted or cached environments.