### PR TITLE
Improve Stardoc docs generation for detekt rule

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -3,8 +3,10 @@ load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 stardoc(
     name = "docs",
     out = "attrs.md",
+    header_template = "//docs:header_template.vm",
     input = "//detekt:defs.bzl",
     rule_template = "//docs:rule_template.vm",
+    symbol_names = ["detekt"],
     deps = [
         "@rules_java//java:rules",
         "@rules_java//java/private:proto_support",

--- a/docs/header_template.vm
+++ b/docs/header_template.vm
@@ -1,0 +1,3 @@
+## This file overrides Stardoc's default header template to suppress the module docstring,
+## which would otherwise appear as a line of text between the generated comment and the content.
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->


### PR DESCRIPTION
Adds a custom header_template.vm to suppress the module docstring that Stardoc injects between the header comment and generated content, and scopes doc generation to only the detekt symbol via symbol_names. Also updates the module docstring in defs.bzl to a single concise line and regenerates docs/attrs.md with the resulting Stardoc output.
