### PR TITLE
Revert "Add support for custom URL templates (#202)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,21 +207,6 @@ detekt.detekt_version(
 use_repo(detekt, "detekt_cli_all")
 ```
 
-To download Detekt from a custom location (e.g. an internal mirror), use the `url_templates` parameter:
-
-```python
-detekt = use_extension("@rules_detekt//detekt:extensions.bzl", "detekt")
-detekt.detekt_version(
-    version = "...",
-    sha256 = "...",
-    url_templates = [
-        "https://my-mirror.example.com/detekt/detekt-cli-{version}-all.jar",
-    ],
-)
-
-use_repo(detekt, "detekt_cli_all")
-```
-
 #### `WORKSPACE` Configuration
 
 ```python
@@ -235,22 +220,6 @@ rules_detekt_dependencies(
     )
 )
 ```
-
-To download Detekt from a custom location (e.g., an internal mirror), use the `url_templates` parameter:
-
-```python
-rules_detekt_dependencies(
-    detekt_version = detekt_version(
-        version = "...",
-        sha256 = "...",
-        url_templates = [
-            "https://my-mirror.example.com/detekt/detekt-cli-{version}-all.jar",
-        ],
-    )
-)
-```
-
-Each template may contain `{version}` which will be replaced with the version string.
 
 ### JVM Flags
 

--- a/detekt/extensions.bzl
+++ b/detekt/extensions.bzl
@@ -15,7 +15,6 @@ _version_tag = tag_class(
     attrs = {
         "version": attr.string(mandatory = True),
         "sha256": attr.string(mandatory = True),
-        "url_templates": attr.string_list(),
     },
 )
 
@@ -32,11 +31,7 @@ def _detekt_impl(mctx):
         for override in mod.tags.detekt_version:
             if detekt_version:
                 fail("Only a single detekt_version at once is supported right now!")
-            detekt_version = _detekt_version(
-                version = override.version,
-                sha256 = override.sha256,
-                url_templates = override.url_templates if override.url_templates else None,
-            )
+            detekt_version = _detekt_version(version = override.version, sha256 = override.sha256)
 
     kwargs = dict(detekt = _DEFAULT_DETEKT_RELEASE)
     if detekt_version:

--- a/detekt/versions.bzl
+++ b/detekt/versions.bzl
@@ -1,26 +1,21 @@
 """Macro for defining detekt versions.
 """
 
-_DEFAULT_URL_TEMPLATES = [
-    "https://github.com/detekt/detekt/releases/download/v{version}/detekt-cli-{version}-all.jar",
-]
-
-def detekt_version(version, sha256, url_templates = None):
+def detekt_version(version, sha256):
     """Create a detekt version.
 
     Args:
         version (str): The version of detekt.
         sha256 (str): The sha256 of the detekt jar.
-        url_templates (list, optional): URL templates for downloading detekt. Each template
-            may contain `{version}` which will be replaced with the version string.
-            Defaults to the standard GitHub release URL.
 
     Returns: A struct containing the version information.
     """
     return struct(
         version = version,
         sha256 = sha256,
-        url_templates = url_templates if url_templates != None else _DEFAULT_URL_TEMPLATES,
+        url_templates = [
+            "https://github.com/detekt/detekt/releases/download/v{version}/detekt-cli-{version}-all.jar",
+        ],
     )
 
 DEFAULT_DETEKT_RELEASE = detekt_version(


### PR DESCRIPTION
This reverts commit ae314e3347f235bac48b8ab164ecdea78440a8b0.

This is unnecessary as `bazel_downloader.cfg` can be used instead.