### PR TITLE
Update registry_fork in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
       attestations: write # Attest provenance
     with:
       tag_name: ${{ github.event.release.tag_name || inputs.tag_name }}
-      registry_fork: bazel-contrib/bazel-central-registry
+      registry_fork: buildfoundation/bazel-central-registry
       # release.yml uses bazel-contrib/.github@v7, which does not produce
       # attestations, so skip attestation upload.
       attest: false


### PR DESCRIPTION
Point at buildfoundation fork, not the upstream one.