### PR TITLE
Fix BCR incompatible flag checks

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,6 +21,7 @@ bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_jvm_external", version = "6.9")
 bazel_dep(name = "bazel_worker_api", version = "0.0.11")
 bazel_dep(name = "bazel_worker_java", version = "0.0.11")
+
 bazel_dep(name = "rules_pmd", version = "0.4.0", dev_dependency = True)
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_jvm_external", version = "6.9")
 bazel_dep(name = "bazel_worker_api", version = "0.0.11")
 bazel_dep(name = "bazel_worker_java", version = "0.0.11")
-bazel_dep(name = "rules_pmd", version = "0.4.0")
+bazel_dep(name = "rules_pmd", version = "0.4.0", dev_dependency = True)
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)
 maven.install(

--- a/detekt/wrapper/BUILD
+++ b/detekt/wrapper/BUILD
@@ -1,5 +1,10 @@
 load("@rules_java//java:defs.bzl", "java_binary", "java_library")
-load("@rules_pmd//pmd:defs.bzl", "pmd_test")
+
+filegroup(
+    name = "sources",
+    srcs = glob(["src/main/java/**/*.java"]),
+    visibility = ["//tests/unit:__pkg__"],
+)
 
 java_library(
     name = "wrapper",
@@ -9,12 +14,6 @@ java_library(
         "@bazel_worker_java//src/main/java/com/google/devtools/build/lib/worker:work_request_handlers",
         "@detekt_cli_all//jar",
     ],
-)
-
-pmd_test(
-    name = "wrapper_pmd_test",
-    srcs = glob(["src/main/java/**/*.java"]),
-    rulesets = ["//:pmd_ruleset.xml"],
 )
 
 java_binary(

--- a/tests/unit/BUILD
+++ b/tests/unit/BUILD
@@ -22,3 +22,9 @@ pmd_test(
     ]),
     rulesets = ["//:pmd_ruleset.xml"],
 )
+
+pmd_test(
+    name = "wrapper_pmd_test",
+    srcs = ["//detekt/wrapper:sources"],
+    rulesets = ["//:pmd_ruleset.xml"],
+)


### PR DESCRIPTION
## Summary

BCR presubmit enables `--incompatible_disable_starlark_host_transitions`. `rules_pmd@0.4.0` still declares `cfg = "host"` in `pmd_test`, so loading `@rules_pmd` through the public `detekt/wrapper` package fails for external consumers.

- Mark `rules_pmd` as a development-only dependency.
- Move `wrapper_pmd_test` to `tests/unit`, exposing wrapper sources through a filegroup.
- Preserve PMD coverage for repository development without loading PMD from public targets.

## Testing

- `pre-commit run --files MODULE.bazel detekt/wrapper/BUILD tests/unit/BUILD`
- `bazel --batch --output_user_root=/private/tmp/bazel-rules-detekt-pmd-pr-test test --lockfile_mode=off //tests/unit:wrapper_pmd_test //tests/unit:tests_pmd_test`
- `bazel --batch --output_user_root=/private/tmp/bazel-rules-detekt-pmd-pr-test build --lockfile_mode=off --incompatible_config_setting_private_default_visibility --incompatible_disable_starlark_host_transitions --incompatible_disable_native_repo_rules --incompatible_autoload_externally= --incompatible_disable_autoloads_in_main_repo --incompatible_strict_action_env //detekt/...`
