### PR TITLE
Preserve Detekt failure diagnostics and expand compatibility tests

### DIFF
--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/execute/Executable.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/execute/Executable.java
@@ -4,11 +4,14 @@ import io.buildfoundation.bazel.detekt.ExecutionUtils;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.List;
 
@@ -42,6 +45,7 @@ public interface Executable {
             }
 
             ExecutableResult result;
+            boolean reportWriteFailed = false;
             Path executionResultOutputPath = Paths.get(ExecutionUtils.getRequiredArgumentValue(detektWrapperArguments, "--execution-result"));
 
             try {
@@ -56,8 +60,15 @@ public interface Executable {
                 try {
                     String output = outputBuffer.toString(charset);
                     String error = errorBuffer.toString(charset);
+                    String diagnostics = output + error;
+                    try {
+                        writeTextReport(detektWrapperArguments, output, error);
+                    } catch (RuntimeException reportError) {
+                        reportWriteFailed = true;
+                        diagnostics += System.lineSeparator() + reportError.getMessage();
+                    }
 
-                    result = new ExecutableResult.Failure(output + error);
+                    result = new ExecutableResult.Failure(diagnostics);
                 } catch (UnsupportedEncodingException unsupportedEncodingException) {
                     result = new ExecutableResult.Failure("Unknown Detekt error, please report this issue");
                 }
@@ -68,10 +79,41 @@ public interface Executable {
 
             ExecutionUtils.writeExecutionResultToFile(result.statusCode(), executionResultOutputPath);
 
-            if (ExecutionUtils.shouldRunAsTestTarget(detektWrapperArguments)) {
+            if (ExecutionUtils.shouldRunAsTestTarget(detektWrapperArguments) && !reportWriteFailed) {
                 result = new ExecutableResult.Success();
             }
             return result;
+        }
+
+        private void writeTextReport(List<String> arguments, String output, String error) {
+            String reportPath = getTextReportPath(arguments);
+            if (reportPath == null || (output.isEmpty() && error.isEmpty())) {
+                return;
+            }
+
+            try {
+                Path path = Paths.get(reportPath);
+                if (!Files.exists(path) || Files.size(path) == 0) {
+                    Files.write(path, (output + error).getBytes(charset), StandardOpenOption.CREATE,
+                            StandardOpenOption.TRUNCATE_EXISTING);
+                } else if (!error.isEmpty()) {
+                    Files.write(path, error.getBytes(charset), StandardOpenOption.APPEND);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to write Detekt text report " + reportPath, e);
+            }
+        }
+
+        private static String getTextReportPath(List<String> arguments) {
+            for (int index = 0; index + 1 < arguments.size(); index++) {
+                if ("--report".equals(arguments.get(index))) {
+                    String report = arguments.get(index + 1);
+                    if (report.startsWith("txt:")) {
+                        return report.substring("txt:".length());
+                    }
+                }
+            }
+            return null;
         }
     }
 

--- a/e2e/compat-v1/BUILD
+++ b/e2e/compat-v1/BUILD
@@ -1,17 +1,36 @@
-load("@rules_detekt//detekt:defs.bzl", "detekt_test")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_detekt//detekt:defs.bzl", "detekt_create_baseline", "detekt_test")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 
 detekt_test(
     name = "compat_v1_test",
-    srcs = ["src/Compat.kt"],
+    srcs = [
+        "src/Compat.kt",
+        "src/CompatTypeResolution.kt",
+    ],
     base_path = ".",
     cfgs = ["detekt.yml"],
-    max_issues = 1,
+    max_issues = 2,
     plugins = [":custom_rules"],
     txt_report = True,
+    deps = [":compat_api"],
+)
+
+detekt_test(
+    name = "compat_v1_report",
+    srcs = [
+        "src/Compat.kt",
+        "src/CompatTypeResolution.kt",
+    ],
+    base_path = ".",
+    cfgs = ["detekt.yml"],
+    max_issues = 2,
+    plugins = [":custom_rules"],
     xml_report = True,
+    deps = [":compat_api"],
 )
 
 kt_jvm_library(
@@ -19,4 +38,81 @@ kt_jvm_library(
     srcs = glob(["custom_rules/src/main/kotlin/**/*.kt"]),
     resources = glob(["custom_rules/src/main/resources/**"]),
     deps = ["@detekt_cli_all//jar"],
+)
+
+kt_jvm_library(
+    name = "compat_api",
+    srcs = ["src/CompatApi.kt"],
+)
+
+detekt_create_baseline(
+    name = "clean_baseline",
+    srcs = ["src/Clean.kt"],
+)
+
+write_file(
+    name = "clean_baseline_expected",
+    out = "clean_baseline_expected.xml",
+    content = [
+        '<?xml version="1.0" ?>',
+        "<SmellBaseline>",
+        "  <ManuallySuppressedIssues></ManuallySuppressedIssues>",
+        "  <CurrentIssues>",
+        "  </CurrentIssues>",
+        "</SmellBaseline>\n",
+    ],
+    newline = "unix",
+)
+
+diff_test(
+    name = "clean_baseline_test",
+    file1 = ":clean_baseline_expected",
+    file2 = ":clean_baseline",
+)
+
+write_file(
+    name = "compat_v1_report_expected",
+    out = "compat_v1_report_expected.xml",
+    content = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<checkstyle version="4.3">',
+        '<file name="src/Compat.kt">',
+        '\t<error line="1" column="1" severity="warning" message="customRuleViolation is forbidden." source="detekt.ForbiddenFunctionName" />',
+        "</file>",
+        '<file name="src/CompatTypeResolution.kt">',
+        '\t<error line="1" column="33" severity="warning" message="CompatApi.name()?.length contains an unnecessary safe call operator" source="detekt.UnnecessarySafeCall" />',
+        "</file>",
+        "</checkstyle>",
+    ],
+    newline = "unix",
+)
+
+diff_test(
+    name = "compat_v1_report_test",
+    file1 = ":compat_v1_report_expected",
+    file2 = ":compat_v1_report",
+)
+
+genrule(
+    name = "compat_v1_txt_report_normalized",
+    testonly = True,
+    srcs = [":compat_v1_test"],
+    outs = ["compat_v1_txt_report_normalized.txt"],
+    cmd = "sed -E 's# at .*/src/# at src/#' $(location :compat_v1_test) > $@",
+)
+
+write_file(
+    name = "compat_v1_txt_report_expected",
+    out = "compat_v1_txt_report_expected.txt",
+    content = [
+        "ForbiddenFunctionName - [customRuleViolation] at src/Compat.kt:1:1 - Signature=Compat.kt$fun customRuleViolation()",
+        "UnnecessarySafeCall - [typeResolutionViolation] at src/CompatTypeResolution.kt:1:33 - Signature=CompatTypeResolution.kt$CompatApi.name()?.length\n",
+    ],
+    newline = "unix",
+)
+
+diff_test(
+    name = "compat_v1_txt_report_test",
+    file1 = ":compat_v1_txt_report_expected",
+    file2 = ":compat_v1_txt_report_normalized",
 )

--- a/e2e/compat-v1/detekt.yml
+++ b/e2e/compat-v1/detekt.yml
@@ -2,3 +2,6 @@ custom:
   active: true
   ForbiddenFunctionName:
     active: true
+potential-bugs:
+  UnnecessarySafeCall:
+    active: true

--- a/e2e/compat-v1/src/Clean.kt
+++ b/e2e/compat-v1/src/Clean.kt
@@ -1,0 +1,1 @@
+class Clean

--- a/e2e/compat-v1/src/CompatApi.kt
+++ b/e2e/compat-v1/src/CompatApi.kt
@@ -1,0 +1,3 @@
+object CompatApi {
+    fun name(): String = "detekt"
+}

--- a/e2e/compat-v1/src/CompatTypeResolution.kt
+++ b/e2e/compat-v1/src/CompatTypeResolution.kt
@@ -1,0 +1,1 @@
+fun typeResolutionViolation() = CompatApi.name()?.length

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -1,6 +1,31 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("//detekt:defs.bzl", "detekt_test")
+load("//detekt:defs.bzl", "detekt_create_baseline", "detekt_test")
+
+detekt_create_baseline(
+    name = "jvm_clean_baseline",
+    srcs = ["//tests/integration/testFixtures/basic-jvm:jvm_static_srcs"],
+)
+
+write_file(
+    name = "jvm_clean_baseline_expected",
+    out = "jvm_clean_baseline_expected.xml",
+    content = [
+        '<?xml version="1.0" ?>',
+        "<SmellBaseline>",
+        "  <ManuallySuppressedIssues></ManuallySuppressedIssues>",
+        "  <CurrentIssues>",
+        "  </CurrentIssues>",
+        "</SmellBaseline>\n",
+    ],
+    newline = "unix",
+)
+
+diff_test(
+    name = "jvm_clean_baseline_test",
+    file1 = ":jvm_clean_baseline_expected",
+    file2 = ":jvm_clean_baseline",
+)
 
 detekt_test(
     name = "jvm_static_analysis_test",

--- a/tests/unit/src/test/java/io/buildfoundation/bazel/detekt/execute/DetektExecutableTests.java
+++ b/tests/unit/src/test/java/io/buildfoundation/bazel/detekt/execute/DetektExecutableTests.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -33,6 +34,167 @@ public class DetektExecutableTests {
     @Test
     public void successResultOnDetektExecutionFailureAsTestTarget() throws IOException {
         check(TestDetekt.ExecuteResult.Failure, ExecutableResult.Success.class, true, 1);
+    }
+
+    @Test
+    public void writesV2TextReportForSuccessfulAnalysis() throws IOException {
+        Path report = reportPath();
+        Path executionResult = Files.createTempFile("detekt-execution-result", ".txt");
+
+        ExecutableResult result = runV2(new String[]{
+                "--input", sourceFile().toString(),
+                "--all-rules",
+                "--fail-on-severity", "Never",
+                "--report", "txt:" + report,
+                "--execution-result", executionResult.toString(),
+        });
+
+        assertEquals(ExecutableResult.Success.class, result.getClass());
+        assertEquals("0", new String(Files.readAllBytes(executionResult)));
+        assertTrue(new String(Files.readAllBytes(report)).contains("UndocumentedPublicClass"));
+    }
+
+    @Test
+    public void writesV2TextReportForFindingsFailure() throws IOException {
+        Path report = reportPath();
+        Path executionResult = Files.createTempFile("detekt-execution-result", ".txt");
+
+        ExecutableResult result = runV2(new String[]{
+                "--input", sourceFile().toString(),
+                "--all-rules",
+                "--report", "txt:" + report,
+                "--execution-result", executionResult.toString(),
+        });
+
+        assertEquals(ExecutableResult.Failure.class, result.getClass());
+        assertEquals("1", new String(Files.readAllBytes(executionResult)));
+        assertTrue(new String(Files.readAllBytes(report)).contains("UndocumentedPublicClass"));
+    }
+
+    @Test
+    public void preservesV2TextReportForFindingsAsTestTarget() throws IOException {
+        Path report = reportPath();
+        Path executionResult = Files.createTempFile("detekt-execution-result", ".txt");
+
+        ExecutableResult result = runV2(new String[]{
+                "--input", sourceFile().toString(),
+                "--all-rules",
+                "--report", "txt:" + report,
+                "--execution-result", executionResult.toString(),
+                "--run-as-test-target",
+        });
+
+        assertEquals(ExecutableResult.Success.class, result.getClass());
+        assertEquals("1", new String(Files.readAllBytes(executionResult)));
+        assertTrue(new String(Files.readAllBytes(report)).contains("UndocumentedPublicClass"));
+    }
+
+    @Test
+    public void writesV2ConfigErrorToTextReportAsTestTarget() throws IOException {
+        Path report = reportPath();
+        Path executionResult = Files.createTempFile("detekt-execution-result", ".txt");
+        Path config = Files.createTempFile("detekt-missing-config", ".yml");
+        Files.delete(config);
+
+        ExecutableResult result = runV2(new String[]{
+                "--input", sourceFile().toString(),
+                "--config", config.toString(),
+                "--report", "txt:" + report,
+                "--execution-result", executionResult.toString(),
+                "--run-as-test-target",
+        });
+
+        assertEquals(ExecutableResult.Success.class, result.getClass());
+        assertEquals("1", new String(Files.readAllBytes(executionResult)));
+        assertTrue(new String(Files.readAllBytes(report)).contains("does not exist"));
+    }
+
+    @Test
+    public void writesV2CliErrorToTextReportAsTestTarget() throws IOException {
+        Path report = reportPath();
+        Path executionResult = Files.createTempFile("detekt-execution-result", ".txt");
+
+        ExecutableResult result = runV2(new String[]{
+                "--input", sourceFile().toString(),
+                "--unknown-option",
+                "--report", "txt:" + report,
+                "--execution-result", executionResult.toString(),
+                "--run-as-test-target",
+        });
+
+        assertEquals(ExecutableResult.Success.class, result.getClass());
+        assertEquals("1", new String(Files.readAllBytes(executionResult)));
+        assertTrue(new String(Files.readAllBytes(report)).contains("unknown-option"));
+    }
+
+    @Test
+    public void writesV2ValidationErrorsToTextReportAsTestTarget() throws IOException {
+        checkV2ValidationError("--jvm-target");
+        checkV2ValidationError("--language-version");
+    }
+
+    @Test
+    public void writesV2TranslationErrorToTextReportAsTestTarget() throws IOException {
+        Path report = reportPath();
+        Path executionResult = Files.createTempFile("detekt-execution-result", ".txt");
+
+        ExecutableResult result = runV2(new String[]{
+                "--input", sourceFile().toString(),
+                "--max-issues", "1",
+                "--report", "txt:" + report,
+                "--execution-result", executionResult.toString(),
+                "--run-as-test-target",
+        });
+
+        assertEquals(ExecutableResult.Success.class, result.getClass());
+        assertEquals("1", new String(Files.readAllBytes(executionResult)));
+        assertTrue(new String(Files.readAllBytes(report)).contains("max_issues"));
+    }
+
+    @Test
+    public void preservesExistingTextReportAndAppendsFailureDiagnostics() throws IOException {
+        Path report = Files.createTempFile("detekt-report", ".txt");
+        Files.write(report, Arrays.asList("native report"));
+        Path executionResult = Files.createTempFile("detekt-execution-result", ".txt");
+
+        Detekt detekt = (args, output, error) -> {
+            output.print("native report\n");
+            error.print("stderr\n");
+            throw new RuntimeException("failure");
+        };
+        ExecutableResult result = new Executable.DetektImpl(detekt).execute(new String[]{
+                "--input", "one",
+                "--report", "txt:" + report,
+                "--execution-result", executionResult.toString(),
+        });
+
+        assertEquals(ExecutableResult.Failure.class, result.getClass());
+        String reportContent = new String(Files.readAllBytes(report));
+        assertTrue(reportContent.startsWith("native report\n"));
+        assertTrue(reportContent.contains("stderr\n"));
+        assertTrue(reportContent.contains("RuntimeException: failure"));
+        assertFalse(reportContent.contains("native report\nnative report\n"));
+    }
+
+    @Test
+    public void keepsFailureStatusWhenTextReportCannotBeWritten() throws IOException {
+        Path report = Files.createTempDirectory("detekt-report");
+        Path executionResult = Files.createTempFile("detekt-execution-result", ".txt");
+
+        Detekt detekt = (args, output, error) -> {
+            throw new RuntimeException("original failure");
+        };
+        ExecutableResult result = new Executable.DetektImpl(detekt).execute(new String[]{
+                "--input", "one",
+                "--report", "txt:" + report,
+                "--execution-result", executionResult.toString(),
+                "--run-as-test-target",
+        });
+
+        assertEquals(ExecutableResult.Failure.class, result.getClass());
+        assertTrue(result.output().contains("RuntimeException: original failure"));
+        assertTrue(result.output().contains("Unable to write Detekt text report"));
+        assertEquals("1", new String(Files.readAllBytes(executionResult)));
     }
 
     @Test
@@ -105,5 +267,36 @@ public class DetektExecutableTests {
         ExecutableResult executableResult = executable.execute(args.toArray(new String[0]));
         assertEquals(result, executableResult.getClass());
         assertEquals(Integer.toString(exitCode), new String(Files.readAllBytes(tempFile)));
+    }
+
+    private ExecutableResult runV2(String[] args) {
+        return new Executable.DetektImpl(new Detekt.Impl()).execute(args);
+    }
+
+    private Path reportPath() throws IOException {
+        return Files.createTempDirectory("detekt-report").resolve("report.txt");
+    }
+
+    private void checkV2ValidationError(String argument) throws IOException {
+        Path report = reportPath();
+        Path executionResult = Files.createTempFile("detekt-execution-result", ".txt");
+
+        ExecutableResult result = runV2(new String[]{
+                "--input", sourceFile().toString(),
+                argument, "not-a-version",
+                "--report", "txt:" + report,
+                "--execution-result", executionResult.toString(),
+                "--run-as-test-target",
+        });
+
+        assertEquals(ExecutableResult.Success.class, result.getClass());
+        assertEquals("1", new String(Files.readAllBytes(executionResult)));
+        assertTrue(new String(Files.readAllBytes(report)).contains(argument));
+    }
+
+    private Path sourceFile() throws IOException {
+        Path source = Files.createTempFile("detekt-source", ".kt");
+        Files.write(source, Arrays.asList("class Undocumented {", "    fun method(): Int = 1", "}"));
+        return source;
     }
 }


### PR DESCRIPTION
## Summary

- Preserve CLI/configuration/validation diagnostics in text reports, including detekt_test; keep existing findings and surface report-write failures.
- Add legacy type-resolution and native text/XML report assertions, plus empty-baseline checks for both Detekt runtimes.
- Cover alpha runtime success, failure, invalid options, and JVM/language-version rejection.

## Validation

- Root suite: 15 tests pass in local and worker modes (27 wrapper/unit cases).
- Detekt 1.23.8 suite: 5 tests pass in local and worker modes.
- External-module smoke test, PMD, and pre-commit pass; root lockfile unchanged.

No change to the JVM target default or version-validation policy.