### PR TITLE
Add native Windows support and CI for both Detekt versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,3 +79,195 @@ jobs:
       - name: "Detekt 1.23.8 compatibility tests"
         working-directory: e2e/compat-v1
         run: bazel test --strategy=Detekt=${{ matrix.detekt-strategy }} //...
+
+  windows:
+    name: Windows (Bazel ${{ matrix.bazel }}, Detekt ${{ matrix.detekt-strategy }})
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: "rules detekt"
+    env:
+      USE_BAZEL_VERSION: ${{ matrix.bazel }}
+    strategy:
+      fail-fast: false
+      matrix:
+        bazel: ["8.x", "9.x"]
+        detekt-strategy: [local, worker]
+    steps:
+      - name: "Checkout the sources"
+        uses: actions/checkout@v7
+        with:
+          path: "rules detekt"
+      - name: "Setup Bazel"
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: true
+          repository-cache: true
+      - name: "Root tests"
+        shell: pwsh
+        run: |
+          # Keep the output root short for Windows tools with MAX_PATH limits.
+          # rules_pmd emits POSIX shell launchers, so its tests remain in the Linux matrix.
+          $bazelArgs = @(
+            "--output_user_root=C:/b",
+            "test",
+            "--modify_execution_info=Detekt=+no-cache",
+            "--nocache_test_results",
+            "--strategy=Detekt=${{ matrix.detekt-strategy }}",
+            "--noenable_runfiles",
+            "//tests/analysis/...",
+            "//tests/integration/...",
+            "//tests/unit:tests"
+          )
+          & bazel @bazelArgs
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: "Run the Detekt 2 expected-failure launcher"
+        working-directory: "rules detekt/e2e/smoke"
+        shell: pwsh
+        run: |
+          $log = Join-Path $env:RUNNER_TEMP "detekt-2-expected-failure.log"
+          $bazelArgs = @(
+            "--output_user_root=C:/b",
+            "test",
+            "--modify_execution_info=Detekt=+no-cache",
+            "--nocache_test_results",
+            "--strategy=Detekt=${{ matrix.detekt-strategy }}",
+            "--noenable_runfiles",
+            "--test_tag_filters=",
+            "--test_output=all",
+            "//:expected_failure_test"
+          )
+          & bazel @bazelArgs *> $log
+          $exitCode = $LASTEXITCODE
+          Get-Content -Path $log
+          $output = [IO.File]::ReadAllText($log)
+          if ($exitCode -ne 3) { throw "expected Detekt 2 test failure (Bazel 3), got $exitCode" }
+          if ($output.Contains("InvalidConfig") -or -not $output.Contains("[UndocumentedPublicClass]")) {
+            throw "expected Detekt 2 finding was not reported"
+          }
+          exit 0
+      - name: "Detekt 1.23.8 compatibility tests"
+        working-directory: "rules detekt/e2e/compat-v1"
+        shell: pwsh
+        run: |
+          $bazelArgs = @(
+            "--output_user_root=C:/b",
+            "test",
+            "--modify_execution_info=Detekt=+no-cache",
+            "--nocache_test_results",
+            "--strategy=Detekt=${{ matrix.detekt-strategy }}",
+            "--noenable_runfiles",
+            "//..."
+          )
+          & bazel @bazelArgs
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: "Run the Detekt 1 expected-failure launcher"
+        working-directory: "rules detekt/e2e/compat-v1"
+        shell: pwsh
+        run: |
+          $log = Join-Path $env:RUNNER_TEMP "detekt-1-expected-failure.log"
+          $bazelArgs = @(
+            "--output_user_root=C:/b",
+            "test",
+            "--modify_execution_info=Detekt=+no-cache",
+            "--nocache_test_results",
+            "--strategy=Detekt=${{ matrix.detekt-strategy }}",
+            "--noenable_runfiles",
+            "--test_tag_filters=",
+            "--test_output=all",
+            "//:expected_failure_test"
+          )
+          & bazel @bazelArgs *> $log
+          $exitCode = $LASTEXITCODE
+          Get-Content -Path $log
+          $output = [IO.File]::ReadAllText($log)
+          if ($exitCode -ne 3) { throw "expected Detekt 1 test failure (Bazel 3), got $exitCode" }
+          if ($output.Contains("InvalidConfig") -or -not $output.Contains("ForbiddenFunctionName -")) {
+            throw "expected Detekt 1 finding was not reported"
+          }
+          exit 0
+      - name: "Run the Detekt 2 baseline copier"
+        shell: pwsh
+        run: |
+          $baseline = Join-Path $PWD "tests/integration/default_baseline.xml"
+          Set-Content -Path $baseline -Value "sentinel" -NoNewline
+          $expected = @(
+            '<?xml version="1.0" ?>',
+            '<SmellBaseline>',
+            '  <ManuallySuppressedIssues></ManuallySuppressedIssues>',
+            '  <CurrentIssues>',
+            '  </CurrentIssues>',
+            '</SmellBaseline>'
+          ) -join "`n"
+          $expected += "`n"
+          try {
+            $bazelArgs = @(
+              "--output_user_root=C:/b",
+              "run",
+              "--modify_execution_info=Detekt=+no-cache",
+              "--strategy=Detekt=${{ matrix.detekt-strategy }}",
+              "--noenable_runfiles",
+              "//tests/integration:jvm_clean_baseline"
+            )
+            & bazel @bazelArgs
+            if ($LASTEXITCODE -ne 0) { throw "Detekt 2 baseline launcher exited with $LASTEXITCODE" }
+            $actual = [IO.File]::ReadAllText($baseline).Replace("`r`n", "`n")
+            if ($actual -eq "sentinel" -or $actual -ne $expected) {
+              Write-Host "Unexpected baseline contents:"
+              Get-Content -Path $baseline
+              throw "Detekt 2 baseline copier did not overwrite the sentinel"
+            }
+          } finally {
+            Remove-Item -Force -ErrorAction SilentlyContinue $baseline
+          }
+      - name: "Run the baseline copier"
+        working-directory: "rules detekt/e2e/compat-v1"
+        shell: pwsh
+        run: |
+          $baseline = Join-Path $PWD "default_baseline.xml"
+          Set-Content -Path $baseline -Value "sentinel" -NoNewline
+          $expected = @(
+            '<?xml version="1.0" ?>',
+            '<SmellBaseline>',
+            '  <ManuallySuppressedIssues></ManuallySuppressedIssues>',
+            '  <CurrentIssues>',
+            '  </CurrentIssues>',
+            '</SmellBaseline>'
+          ) -join "`n"
+          $expected += "`n"
+          try {
+            $bazelArgs = @(
+              "--output_user_root=C:/b",
+              "run",
+              "--modify_execution_info=Detekt=+no-cache",
+              "--strategy=Detekt=${{ matrix.detekt-strategy }}",
+              "--noenable_runfiles",
+              "//:baseline with spaces"
+            )
+            & bazel @bazelArgs
+            if ($LASTEXITCODE -ne 0) { throw "baseline launcher exited with $LASTEXITCODE" }
+            $actual = [IO.File]::ReadAllText($baseline).Replace("`r`n", "`n")
+            if ($actual -eq "sentinel" -or $actual -ne $expected) {
+              Write-Host "Unexpected baseline contents:"
+              Get-Content -Path $baseline
+              throw "baseline copier did not overwrite the sentinel with the expected baseline"
+            }
+          } finally {
+            Remove-Item -Force -ErrorAction SilentlyContinue $baseline
+          }
+      - name: "External smoke test"
+        working-directory: "rules detekt/e2e/smoke"
+        shell: pwsh
+        run: |
+          $bazelArgs = @(
+            "--output_user_root=C:/b",
+            "test",
+            "--modify_execution_info=Detekt=+no-cache",
+            "--nocache_test_results",
+            "--strategy=Detekt=${{ matrix.detekt-strategy }}",
+            "--noenable_runfiles",
+            "//..."
+          )
+          & bazel @bazelArgs
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,6 +12,7 @@ use_repo(detekt, "detekt_cli_all")
 
 bazel_dep(name = "rules_android", version = "0.7.3")
 bazel_dep(name = "rules_java", version = "9.3.0")
+bazel_dep(name = "platforms", version = "1.0.0")
 
 bazel_dep(name = "hermetic_android_toolchains", version = "0.3.0", dev_dependency = True)
 bazel_dep(name = "rules_kotlin", version = "2.4.0", dev_dependency = True)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ For detailed per-Detekt-version Kotlin and JDK compatibility, see the [Detekt co
 
 The project is developed and tested against **Bazel 8 and 9** with Bzlmod.
 
+### Windows
+
+Windows CI covers Bazel 8 and 9 with both local and persistent-worker Detekt
+execution. The rules use native Windows launchers and manifest-only runfiles,
+so Developer Mode and filesystem symlinks are not required. Keep Bazel's
+output root short (for example, `--output_user_root=C:/b`) to avoid Windows
+path-length limits.
+
 ## Usage
 
 Refer to [GitHub releases](https://github.com/buildfoundation/bazel_rules_detekt/releases) for the version and the SHA-256 hashsum.

--- a/detekt/BUILD
+++ b/detekt/BUILD
@@ -17,5 +17,6 @@ toolchain(
 
 exports_files([
     "defs.bzl",
+    "result_script.bat.tpl",
     "result_script.sh.tpl",
 ])

--- a/detekt/defs.bzl
+++ b/detekt/defs.bzl
@@ -14,6 +14,13 @@ _ATTRS = {
         default = Label("//detekt:result_script.sh.tpl"),
         allow_single_file = True,
     ),
+    "_result_script_bat_template": attr.label(
+        default = Label("//detekt:result_script.bat.tpl"),
+        allow_single_file = True,
+    ),
+    "_windows_constraint": attr.label(
+        default = Label("@platforms//os:windows"),
+    ),
     "srcs": attr.label_list(
         mandatory = True,
         allow_files = [".kt", ".kts"],
@@ -122,10 +129,22 @@ TOOLCHAIN_TYPE = Label("//detekt:toolchain_type")
 ANDROID_SDK_TOOLCHAIN_TYPE = Label("@rules_android//toolchains/android_sdk:toolchain_type")
 JDK_TOOLCHAIN_TYPE = Label("@bazel_tools//tools/jdk:toolchain_type")
 
+def _runfiles_path(ctx, file):
+    """Returns the manifest key for a file in this target's runfiles."""
+    short_path = file.short_path
+    if short_path.startswith("../"):
+        # External repository paths already contain Bazel's canonical runfiles
+        # repository name (for example, ../+repo+extension/path).
+        return short_path[3:]
+    if ctx.workspace_name:
+        return "{}/{}".format(ctx.workspace_name, short_path)
+    return short_path
+
 def _impl(
         ctx,
         run_as_test_target = False,
         create_baseline = False):
+    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
     action_inputs = []
     action_outputs = []
 
@@ -164,16 +183,34 @@ def _impl(
         run_files.append(internal_baseline)
         action_outputs.append(internal_baseline)
         detekt_arguments.add("--baseline", internal_baseline)
-        final_baseline = ctx.files.baseline[0].short_path if len(ctx.files.baseline) != 0 else "%s/%s" % (ctx.label.package, default_baseline)
+        final_baseline = ctx.files.baseline[0].short_path if len(ctx.files.baseline) != 0 else "/".join([part for part in [ctx.label.package, default_baseline] if part])
 
-        baseline_script = """
+        if is_windows:
+            baseline_script = """
+if not defined BUILD_WORKING_DIRECTORY (
+    echo BUILD_WORKING_DIRECTORY is not set 1>&2
+    exit /b 1
+)
+set "BUILD_WORKING_DIRECTORY=%BUILD_WORKING_DIRECTORY:/=\\%"
+if not defined baseline_file (
+    echo Unable to locate generated baseline 1>&2
+    exit /b 1
+)
+copy /Y "%baseline_file%" "%BUILD_WORKING_DIRECTORY%\\{target}" >nul
+if errorlevel 1 exit /b 1
+echo Updated "{target}"
+""".format(
+                target = final_baseline.replace("/", "\\"),
+            )
+        else:
+            baseline_script = """
                     #!/bin/bash
-                    cp -rf {source} $BUILD_WORKING_DIRECTORY/{target}
-                    echo "$(tput setaf 2)Updated {target} $(tput sgr0)"
+                    cp -f "{source}" "$BUILD_WORKING_DIRECTORY/{target}"
+                    echo "Updated {target}"
                             """.format(
-            source = internal_baseline.short_path,
-            target = final_baseline,
-        )
+                source = internal_baseline.short_path,
+                target = final_baseline,
+            )
     elif ctx.attr.baseline != None:
         action_inputs.append(ctx.file.baseline)
         detekt_arguments.add("--baseline", ctx.file.baseline)
@@ -275,16 +312,27 @@ def _impl(
     )
     run_files.append(txt_report)
 
-    # Note: this is not compatible with Windows, feel free to submit PR!
-    # text report-contents are always printed to shell
-    result_script = ctx.actions.declare_file(ctx.attr.name + ".sh")
+    execution_result_path = _runfiles_path(ctx, execution_result) if is_windows else execution_result.short_path
+    text_report_path = _runfiles_path(ctx, txt_report) if is_windows else txt_report.short_path
+    baseline_file_path = _runfiles_path(ctx, internal_baseline) if is_windows and internal_baseline else ""
+    baseline_lookup = ""
+    if baseline_file_path:
+        baseline_lookup = """
+set "baseline_file="
+call :rlocation "{baseline_file}" baseline_file
+if defined baseline_file set "baseline_file=%baseline_file:/=\\%"
+""".format(baseline_file = baseline_file_path)
+
+    # Text report contents are always printed by the launcher.
+    result_script = ctx.actions.declare_file(ctx.attr.name + (".bat" if is_windows else ".sh"))
     ctx.actions.expand_template(
         output = result_script,
-        template = ctx.file._result_script_template,
+        template = ctx.file._result_script_bat_template if is_windows else ctx.file._result_script_template,
         substitutions = {
             "{baseline_script}": baseline_script,
-            "{execution_result}": execution_result.short_path,
-            "{text_report}": txt_report.short_path,
+            "{baseline_file_lookup}": baseline_lookup,
+            "{execution_result}": execution_result_path,
+            "{text_report}": text_report_path,
         },
         is_executable = True,
     )

--- a/detekt/result_script.bat.tpl
+++ b/detekt/result_script.bat.tpl
@@ -1,0 +1,41 @@
+@echo off
+setlocal EnableExtensions DisableDelayedExpansion
+
+if not defined RUNFILES_MANIFEST_FILE if defined TEST_SRCDIR if exist "%TEST_SRCDIR%\MANIFEST" set "RUNFILES_MANIFEST_FILE=%TEST_SRCDIR%\MANIFEST"
+if not defined RUNFILES_MANIFEST_FILE if defined RUNFILES_DIR if exist "%RUNFILES_DIR%_manifest" set "RUNFILES_MANIFEST_FILE=%RUNFILES_DIR%_manifest"
+if not defined RUNFILES_MANIFEST_FILE if defined RUNFILES_DIR if exist "%RUNFILES_DIR%\MANIFEST" set "RUNFILES_MANIFEST_FILE=%RUNFILES_DIR%\MANIFEST"
+if not defined RUNFILES_MANIFEST_FILE if exist "%~f0.runfiles_manifest" set "RUNFILES_MANIFEST_FILE=%~f0.runfiles_manifest"
+if not defined RUNFILES_MANIFEST_FILE if exist "%~f0.runfiles\MANIFEST" set "RUNFILES_MANIFEST_FILE=%~f0.runfiles\MANIFEST"
+if defined RUNFILES_DIR set "RUNFILES_DIR=%RUNFILES_DIR:/=\%"
+if defined RUNFILES_MANIFEST_FILE set "RUNFILES_MANIFEST_FILE=%RUNFILES_MANIFEST_FILE:/=\%"
+
+set "execution_result="
+call :rlocation "{execution_result}" execution_result
+if defined execution_result set "execution_result=%execution_result:/=\%"
+if not defined execution_result (
+    echo Unable to locate Detekt execution result 1>&2
+    exit /b 1
+)
+
+set "text_report="
+call :rlocation "{text_report}" text_report
+if defined text_report set "text_report=%text_report:/=\%"
+if defined text_report if exist "%text_report%" type "%text_report%"
+
+{baseline_file_lookup}
+set "exit_code="
+set /p "exit_code="<"%execution_result%"
+if not defined exit_code set "exit_code=1"
+{baseline_script}
+exit /b %exit_code%
+
+:rlocation
+set "%~2="
+if defined RUNFILES_DIR if exist "%RUNFILES_DIR%\%~1" set "%~2=%RUNFILES_DIR%\%~1"
+set "manifest_runfile_path=%~1"
+set "manifest_runfile_path=%manifest_runfile_path:\=\b%"
+set "manifest_runfile_path=%manifest_runfile_path: =\s%"
+if defined RUNFILES_MANIFEST_FILE if exist "%RUNFILES_MANIFEST_FILE%" if not defined %~2 (
+    for /f "usebackq tokens=1,* delims= " %%A in ("%RUNFILES_MANIFEST_FILE%") do if "%%A"=="%manifest_runfile_path%" set "%~2=%%B"
+)
+exit /b 0

--- a/e2e/compat-v1/.bazelrc
+++ b/e2e/compat-v1/.bazelrc
@@ -1,0 +1,1 @@
+common --test_tag_filters=-manual

--- a/e2e/compat-v1/BUILD
+++ b/e2e/compat-v1/BUILD
@@ -20,6 +20,16 @@ detekt_test(
 )
 
 detekt_test(
+    name = "expected_failure_test",
+    srcs = ["src/Compat.kt"],
+    base_path = ".",
+    cfgs = ["detekt.yml"],
+    max_issues = 0,
+    plugins = [":custom_rules"],
+    tags = ["manual"],
+)
+
+detekt_test(
     name = "compat_v1_report",
     srcs = [
         "src/Compat.kt",
@@ -43,6 +53,12 @@ kt_jvm_library(
 kt_jvm_library(
     name = "compat_api",
     srcs = ["src/CompatApi.kt"],
+)
+
+detekt_create_baseline(
+    name = "baseline with spaces",
+    srcs = ["src/Clean.kt"],
+    tags = ["manual"],
 )
 
 detekt_create_baseline(
@@ -99,6 +115,11 @@ genrule(
     srcs = [":compat_v1_test"],
     outs = ["compat_v1_txt_report_normalized.txt"],
     cmd = "sed -E 's# at .*/src/# at src/#' $(location :compat_v1_test) > $@",
+    cmd_ps = """
+$$text = [IO.File]::ReadAllText('$(location :compat_v1_test)').Replace('\\', '/')
+$$text = $$text.Replace("`r`n", "`n") -replace ' at .*/src/', ' at src/'
+[IO.File]::WriteAllText('$@', $$text, [Text.UTF8Encoding]::new($$false))
+""",
 )
 
 write_file(

--- a/e2e/smoke/.bazelrc
+++ b/e2e/smoke/.bazelrc
@@ -1,1 +1,2 @@
 common --repo_env=ACCEPTED_ANDROID_SDK_LICENSE_VERSION=35
+common --test_tag_filters=-manual

--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -4,3 +4,11 @@ detekt_test(
     name = "smoke_test",
     srcs = ["Smoke.kt"],
 )
+
+detekt_test(
+    name = "expected_failure_test",
+    srcs = ["Smoke.kt"],
+    all_rules = True,
+    fail_on_severity = "Warning",
+    tags = ["manual"],
+)

--- a/tests/analysis/BUILD
+++ b/tests/analysis/BUILD
@@ -1,5 +1,13 @@
 load(":tests.bzl", "test_suite")
 
+platform(
+    name = "windows_platform",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+    ],
+)
+
 test_suite(
     name = "tests",
 )

--- a/tests/analysis/tests.bzl
+++ b/tests/analysis/tests.bzl
@@ -3,7 +3,7 @@ The rule analysis tests.
 """
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
-load("//detekt:defs.bzl", "detekt")
+load("//detekt:defs.bzl", "detekt", "detekt_create_baseline")
 
 def _expand_path(ctx, value):
     source_dir = ctx.build_file_path.replace("/BUILD", "")
@@ -17,13 +17,19 @@ def _expand_paths(ctx, values):
     ]
 
 def _input_short_path(file):
-    path = file.short_path
+    path = file.short_path.replace("\\", "/")
     prefix = "_middlemen/"
     suffix = "-runfiles"
     if path.startswith(prefix) and path.endswith(suffix):
         # Bazel 8: _middlemen/detekt_Swrapper_Sbin-runfiles
         # Bazel 9: detekt/wrapper/bin.runfiles
-        return path[len(prefix):len(path) - len(suffix)].replace("_S", "/") + ".runfiles"
+        path = path[len(prefix):len(path) - len(suffix)].replace("_S", "/") + ".runfiles"
+    if path.endswith(".exe.runfiles"):
+        return path[:-len(".exe.runfiles")] + ".runfiles"
+    if path.endswith(".exe.runfiles_manifest"):
+        return path[:-len(".exe.runfiles_manifest")] + ".runfiles_manifest"
+    if path.endswith(".exe"):
+        return path[:-len(".exe")]
     return path
 
 def _input_short_paths(files):
@@ -32,9 +38,54 @@ def _input_short_paths(files):
         for file in files.to_list()
     ]
 
+def _normalize_path(value):
+    return value.replace("\\", "/")
+
+def _assert_wrapper_inputs(env, action):
+    wrapper_paths = [
+        _input_short_path(file)
+        for file in action.inputs.to_list()
+        if _normalize_path(file.short_path).startswith("detekt/wrapper/bin") or _normalize_path(file.short_path).startswith("_middlemen/detekt_Swrapper_Sbin")
+    ]
+    asserts.true(
+        env,
+        "detekt/wrapper/bin" in wrapper_paths,
+        "Expected the Detekt wrapper executable in {paths}".format(paths = wrapper_paths),
+    )
+    asserts.true(
+        env,
+        "detekt/wrapper/bin.jar" in wrapper_paths,
+        "Expected the Detekt wrapper jar in {paths}".format(paths = wrapper_paths),
+    )
+    asserts.true(
+        env,
+        any([path.endswith(".runfiles") for path in wrapper_paths]) or any([path.endswith(".runfiles_manifest") for path in wrapper_paths]),
+        "Expected wrapper runfiles in {paths}".format(paths = wrapper_paths),
+    )
+    allowed_wrapper_paths = [
+        "detekt/wrapper/bin",
+        "detekt/wrapper/bin.jar",
+        "detekt/wrapper/bin.runfiles",
+        "detekt/wrapper/bin.runfiles_manifest",
+    ]
+    asserts.equals(
+        env,
+        sorted([path for path in wrapper_paths if path in allowed_wrapper_paths]),
+        sorted(wrapper_paths),
+    )
+
 def assert_argv_contains_prefix_suffix(env, action, prefix, suffix):
+    """Fails unless an action argument has the requested prefix and suffix.
+
+    Args:
+      env: Analysis test environment.
+      action: Action whose arguments are inspected.
+      prefix: Required argument prefix.
+      suffix: Required argument suffix.
+    """
     for arg in action.argv:
-        if arg.startswith(prefix) and arg.endswith(suffix):
+        normalized = _normalize_path(arg)
+        if normalized.startswith(_normalize_path(prefix)) and normalized.endswith(_normalize_path(suffix)):
             return
     unittest.fail(
         env,
@@ -45,10 +96,24 @@ def assert_argv_contains_prefix_suffix(env, action, prefix, suffix):
         ),
     )
 
+def _assert_argv_contains_executable(env, action, prefix, suffix):
+    for arg in action.argv:
+        normalized = _normalize_path(arg)
+        if (normalized.startswith(_normalize_path(prefix)) or "/" + _normalize_path(prefix) in normalized) and (normalized.endswith(_normalize_path(suffix)) or normalized.endswith(_normalize_path(suffix + ".exe"))):
+            return
+    unittest.fail(
+        env,
+        "Expected an executable arg with prefix '{prefix}' and suffix '{suffix}' in {args}".format(
+            prefix = prefix,
+            suffix = suffix,
+            args = action.argv,
+        ),
+    )
+
 def assert_argv_contains(env, action, flag):
     asserts.true(
         env,
-        flag in action.argv,
+        flag in [_normalize_path(arg) for arg in action.argv],
         "Expected {args} to contain {flag}".format(args = action.argv, flag = flag),
     )
 
@@ -57,11 +122,11 @@ def assert_argv_contains(env, action, flag):
 def _action_full_contents_test_impl(ctx):
     env = analysistest.begin(ctx)
 
-    actions = analysistest.target_actions(env)
-    asserts.equals(env, 6, len(actions))
+    actions = [action for action in analysistest.target_actions(env) if action.mnemonic == "Detekt"]
+    asserts.equals(env, 1, len(actions))
 
     action = actions[0]
-    assert_argv_contains_prefix_suffix(env, action, "bazel-out/", "/detekt/wrapper/bin")
+    _assert_argv_contains_executable(env, action, "bazel-out/", "/detekt/wrapper/bin")
     assert_argv_contains(env, action, "--jvm_flag=-Xms16m")
     assert_argv_contains(env, action, "--jvm_flag=-Xmx128m")
     assert_argv_contains(env, action, "--input")
@@ -90,10 +155,15 @@ def _action_full_contents_test_impl(ctx):
         "tests/analysis/config B.yml",
         "tests/analysis/config C.yml",
         "tests/analysis/baseline.xml",
-        "detekt/wrapper/bin",
-        "detekt/wrapper/bin.jar",
-        "detekt/wrapper/bin.runfiles",
     ])
+
+    actual_inputs = _input_short_paths(action.inputs)
+    asserts.equals(
+        env,
+        sorted(expected_inputs),
+        sorted([path for path in actual_inputs if not path.startswith("detekt/wrapper/bin")]),
+    )
+    _assert_wrapper_inputs(env, action)
 
     expected_outputs = _expand_paths(env.ctx, [
         "{{source_dir}}/test_target_full_detekt_report.txt",
@@ -102,7 +172,6 @@ def _action_full_contents_test_impl(ctx):
         "{{source_dir}}/test_target_full_exit_code.txt",
     ])
 
-    asserts.equals(env, expected_inputs, _input_short_paths(action.inputs))
     asserts.equals(env, expected_outputs, [file.short_path for file in action.outputs.to_list()])
 
     return analysistest.end(env)
@@ -135,11 +204,11 @@ def _test_action_full_contents():
 def _action_blank_contents_test_impl(ctx):
     env = analysistest.begin(ctx)
 
-    actions = analysistest.target_actions(env)
-    asserts.equals(env, 6, len(actions))
+    actions = [action for action in analysistest.target_actions(env) if action.mnemonic == "Detekt"]
+    asserts.equals(env, 1, len(actions))
 
     action = actions[0]
-    assert_argv_contains_prefix_suffix(env, action, "bazel-out/", "/detekt/wrapper/bin")
+    _assert_argv_contains_executable(env, action, "bazel-out/", "/detekt/wrapper/bin")
     assert_argv_contains(env, action, "--jvm_flag=-Xms16m")
     assert_argv_contains(env, action, "--jvm_flag=-Xmx128m")
     assert_argv_contains(env, action, "--input")
@@ -151,17 +220,21 @@ def _action_blank_contents_test_impl(ctx):
         "tests/analysis/path A.kt",
         "tests/analysis/path B.kt",
         "tests/analysis/path C.kt",
-        "detekt/wrapper/bin",
-        "detekt/wrapper/bin.jar",
-        "detekt/wrapper/bin.runfiles",
     ])
+
+    actual_inputs = _input_short_paths(action.inputs)
+    asserts.equals(
+        env,
+        sorted(expected_inputs),
+        sorted([path for path in actual_inputs if not path.startswith("detekt/wrapper/bin")]),
+    )
+    _assert_wrapper_inputs(env, action)
 
     expected_outputs = _expand_paths(env.ctx, [
         "{{source_dir}}/test_target_blank_detekt_report.txt",
         "{{source_dir}}/test_target_blank_exit_code.txt",
     ])
 
-    asserts.equals(env, expected_inputs, _input_short_paths(action.inputs))
     asserts.equals(env, expected_outputs, [file.short_path for file in action.outputs.to_list()])
 
     return analysistest.end(env)
@@ -185,8 +258,8 @@ def _test_action_blank_contents():
 def _action_failure_policy_impl(ctx):
     env = analysistest.begin(ctx)
 
-    actions = analysistest.target_actions(env)
-    asserts.equals(env, 6, len(actions))
+    actions = [action for action in analysistest.target_actions(env) if action.mnemonic == "Detekt"]
+    asserts.equals(env, 1, len(actions))
 
     action = actions[0]
     assert_argv_contains(env, action, "--fail-on-severity")
@@ -209,12 +282,67 @@ def _test_action_failure_policy():
         target_under_test = ":test_target_failure_policy",
     )
 
+# Windows result launcher selection
+
+def _windows_result_launcher_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    executable = target[DefaultInfo].files_to_run.executable
+
+    asserts.true(env, executable.short_path.endswith(".bat"))
+    asserts.false(env, executable.short_path.endswith(".sh"))
+
+    launcher_actions = [
+        action
+        for action in analysistest.target_actions(env)
+        if action.mnemonic == "TemplateExpand" and action.outputs.to_list()[0].short_path.endswith(".bat")
+    ]
+    asserts.equals(env, 1, len(launcher_actions))
+    launcher_inputs = _input_short_paths(launcher_actions[0].inputs)
+    asserts.equals(env, ["detekt/result_script.bat.tpl"], launcher_inputs)
+
+    runfile_paths = [
+        file.short_path
+        for file in target[DefaultInfo].default_runfiles.files.to_list()
+    ]
+    asserts.true(env, "tests/analysis/test_target_windows_launcher_exit_code.txt" in runfile_paths)
+    asserts.true(env, "tests/analysis/test_target_windows_launcher_detekt_report.txt" in runfile_paths)
+    asserts.true(env, "tests/analysis/test_target_windows_launcher_baseline.xml" in runfile_paths)
+
+    return analysistest.end(env)
+
+windows_result_launcher_test = analysistest.make(
+    _windows_result_launcher_test_impl,
+    config_settings = {
+        "//command_line_option:platforms": str(Label("//tests/analysis:windows_platform")),
+    },
+)
+
+def _test_windows_result_launcher():
+    detekt_create_baseline(
+        name = "test_target_windows_launcher",
+        srcs = ["path A.kt"],
+        baseline = "baseline.xml",
+        tags = ["manual"],
+    )
+
+    windows_result_launcher_test(
+        name = "windows_result_launcher_test",
+        target_under_test = ":test_target_windows_launcher",
+    )
+
 # Suite
 
 def test_suite(name):
+    """Creates the Detekt rule analysis test suite.
+
+    Args:
+      name: Name of the generated test suite.
+    """
     _test_action_full_contents()
     _test_action_blank_contents()
     _test_action_failure_policy()
+    _test_windows_result_launcher()
 
     native.test_suite(
         name = name,
@@ -222,5 +350,6 @@ def test_suite(name):
             ":action_full_contents_test",
             ":action_blank_contents_test",
             ":action_failure_policy_test",
+            ":windows_result_launcher_test",
         ],
     )

--- a/tests/unit/src/test/java/io/buildfoundation/bazel/detekt/ExecutionUtilsTests.java
+++ b/tests/unit/src/test/java/io/buildfoundation/bazel/detekt/ExecutionUtilsTests.java
@@ -74,4 +74,21 @@ public class ExecutionUtilsTests {
         List<String> expectedArgs = new ArrayList<>(Arrays.asList("--input", "one"));
         assertEquals(ExecutionUtils.sanitizeDetektArguments(args), expectedArgs);
     }
+
+    @Test
+    public void sanitizeDetektArgumentsPreservesWindowsPathsWithSpaces() {
+        String source = "C:\\workspace with spaces\\src\\Main.kt";
+        String report = "C:\\workspace with spaces\\out\\detekt report.txt";
+        String executionResult = "C:\\workspace with spaces\\out\\exit code.txt";
+        List<String> args = new ArrayList<>(Arrays.asList(
+                "--input", source,
+                "--report", "txt:" + report,
+                "--execution-result", executionResult
+        ));
+
+        assertEquals(Arrays.asList(
+                "--input", source,
+                "--report", "txt:" + report
+        ), ExecutionUtils.sanitizeDetektArguments(args));
+    }
 }

--- a/tests/unit/src/test/java/io/buildfoundation/bazel/detekt/execute/DetektExecutableTests.java
+++ b/tests/unit/src/test/java/io/buildfoundation/bazel/detekt/execute/DetektExecutableTests.java
@@ -3,6 +3,7 @@ package io.buildfoundation.bazel.detekt.execute;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -153,8 +154,8 @@ public class DetektExecutableTests {
 
     @Test
     public void preservesExistingTextReportAndAppendsFailureDiagnostics() throws IOException {
-        Path report = Files.createTempFile("detekt-report", ".txt");
-        Files.write(report, Arrays.asList("native report"));
+        Path report = Files.createTempFile("detekt report", ".txt");
+        Files.write(report, "native report\n".getBytes(StandardCharsets.UTF_8));
         Path executionResult = Files.createTempFile("detekt-execution-result", ".txt");
 
         Detekt detekt = (args, output, error) -> {


### PR DESCRIPTION
## Summary

- Add native Windows result launchers with manifest runfiles, failure reporting, and baseline copying; preserve POSIX behavior.
- Validate Detekt 2 alpha and 1.23.8 on Windows with Bazel 8/9, local/worker execution, and no runfiles symlinks.
- Cover real test failures, baseline overwrite, paths with spaces, and portable newline handling.

## Validation

- Root suite: all 16 tests pass locally in local and forced worker modes.
- Detekt 1.23.8 compatibility: all 5 tests pass; both versions report expected test failures.
- Both baseline copiers verified against expected XML, including a spaced generated filename.
- Pre-commit hooks and lockfile validation pass.
- Native Windows validation runs in this PR’s new GitHub Actions jobs.