### PR TITLE
Test failure enforcement for both Detekt runtimes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,17 @@ jobs:
           repository-cache: true
       - name: "Unit tests"
         run: bazel test --strategy=Detekt=${{ matrix.detekt-strategy }} //...
+      - name: "External Detekt 2 smoke test"
+        working-directory: e2e/smoke
+        run: bazel test --strategy=Detekt=${{ matrix.detekt-strategy }} --modify_execution_info=Detekt=+no-cache --nocache_test_results //:smoke_test
+      - name: "Detekt 2 failure gate"
+        working-directory: e2e/smoke
+        shell: bash
+        run: |
+          status=0
+          bazel test --strategy=Detekt=${{ matrix.detekt-strategy }} --modify_execution_info=Detekt=+no-cache --nocache_test_results --test_tag_filters= --test_output=all //:expected_failure_test 2>&1 | tee "$RUNNER_TEMP/detekt-2-failure.log" || status=$?
+          test "$status" -eq 3
+          grep -F "[UndocumentedPublicClass]" "$RUNNER_TEMP/detekt-2-failure.log"
       - name: Verify MODULE.bazel.lock is unchanged
         if: ${{ always() && matrix.bazel == '9.x' && matrix.detekt-strategy == 'local' }}
         shell: bash
@@ -79,3 +90,11 @@ jobs:
       - name: "Detekt 1.23.8 compatibility tests"
         working-directory: e2e/compat-v1
         run: bazel test --strategy=Detekt=${{ matrix.detekt-strategy }} //...
+      - name: "Detekt 1.23.8 failure gate"
+        working-directory: e2e/compat-v1
+        shell: bash
+        run: |
+          status=0
+          bazel test --strategy=Detekt=${{ matrix.detekt-strategy }} --modify_execution_info=Detekt=+no-cache --nocache_test_results --test_tag_filters= --test_output=all //:expected_failure_test 2>&1 | tee "$RUNNER_TEMP/detekt-1-failure.log" || status=$?
+          test "$status" -eq 3
+          grep -F "ForbiddenFunctionName - [customRuleViolation]" "$RUNNER_TEMP/detekt-1-failure.log"

--- a/e2e/compat-v1/BUILD
+++ b/e2e/compat-v1/BUILD
@@ -20,6 +20,16 @@ detekt_test(
 )
 
 detekt_test(
+    name = "expected_failure_test",
+    srcs = ["src/Compat.kt"],
+    base_path = ".",
+    cfgs = ["detekt.yml"],
+    max_issues = 0,
+    plugins = [":custom_rules"],
+    tags = ["manual"],
+)
+
+detekt_test(
     name = "compat_v1_report",
     srcs = [
         "src/Compat.kt",

--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -4,3 +4,11 @@ detekt_test(
     name = "smoke_test",
     srcs = ["Smoke.kt"],
 )
+
+detekt_test(
+    name = "expected_failure_test",
+    srcs = ["Smoke.kt"],
+    all_rules = True,
+    fail_on_severity = "Warning",
+    tags = ["manual"],
+)


### PR DESCRIPTION
## Summary

- Add end-to-end failure checks for Detekt 2.0.0-alpha.6 and 1.23.8 in the existing local/worker CI jobs.
- Require Bazel test-failure exit code 3 and real finding output; startup or configuration failures cannot satisfy the gate.
- Run the external alpha smoke test across the existing Bazel matrix. Keep deliberate failures manual so normal test suites remain green.

## Validation

- Root suite: all 15 tests pass.
- Both runtimes: success and expected-failure checks pass locally with local and worker strategies.
- CI shell positive/negative controls, pre-commit, and unchanged root lockfile verified.

No runtime or Windows-support changes; independent of PR #250.